### PR TITLE
Add offline teacher-embedding precompute pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "triplets"
-version = "0.24.0-alpha"
+version = "0.24.1-alpha"
 dependencies = [
  "bitcode",
  "bm25",
@@ -2806,6 +2806,7 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "reqwest 0.13.4",
+ "reqwest-drive",
  "serde",
  "serde_json",
  "simd-r-drive",
@@ -2823,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "triplets-core"
-version = "0.24.0-alpha"
+version = "0.24.1-alpha"
 dependencies = [
  "bitcode",
  "bm25",
@@ -2847,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "triplets-debug"
-version = "0.24.0-alpha"
+version = "0.24.1-alpha"
 dependencies = [
  "cache-manager",
  "chrono",
@@ -2863,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "triplets-hf-source"
-version = "0.24.0-alpha"
+version = "0.24.1-alpha"
 dependencies = [
  "cache-manager",
  "chrono",
@@ -2884,6 +2885,30 @@ dependencies = [
  "triplets-core",
  "triplets-hf-source",
  "walkdir",
+]
+
+[[package]]
+name = "triplets-offline-embedder"
+version = "0.24.1-alpha"
+dependencies = [
+ "simd-r-drive",
+ "tempfile",
+ "triplets-core",
+ "triplets-offline-embedder",
+ "triplets-srd-source",
+]
+
+[[package]]
+name = "triplets-srd-source"
+version = "0.24.1-alpha"
+dependencies = [
+ "chrono",
+ "simd-r-drive",
+ "tempfile",
+ "thiserror",
+ "triplets",
+ "triplets-core",
+ "triplets-srd-source",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,14 @@ members = [
     ".",
     "crates/triplets-core",
     "crates/triplets-debug",
+    "crates/triplets-offline-embedder",
     "crates/triplets-hf-source",
+    "crates/triplets-srd-source",
 ]
 resolver = "2"
 
 [workspace.package]
-version = "0.24.0-alpha"
+version = "0.24.1-alpha"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
@@ -60,14 +62,17 @@ thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["rt", "fs", "io-util"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-triplets-core = { path = "crates/triplets-core", version = "0.24.0-alpha" }
-triplets-debug = { path = "crates/triplets-debug", version = "0.24.0-alpha" }
-triplets-hf-source = { path = "crates/triplets-hf-source", version = "0.24.0-alpha" }
+triplets = { path = ".", version = "0.24.1-alpha" }
+triplets-core = { path = "crates/triplets-core", version = "0.24.1-alpha" }
+triplets-debug = { path = "crates/triplets-debug", version = "0.24.1-alpha" }
+triplets-offline-embedder = { path = "crates/triplets-offline-embedder", version = "0.24.1-alpha" }
+triplets-hf-source = { path = "crates/triplets-hf-source", version = "0.24.1-alpha" }
+triplets-srd-source = { path = "crates/triplets-srd-source", version = "0.24.1-alpha" }
 walkdir = "2.5.0"
 
 [features]
 default = []
-huggingface = ["dep:triplets-hf-source"]
+huggingface = ["dep:triplets-hf-source", "reqwest-drive"]
 bm25-mining = ["dep:bm25", "triplets-core/bm25-mining"]
 extended-metrics = ["triplets-core/extended-metrics"]
 
@@ -85,6 +90,7 @@ parquet = { workspace = true, optional = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 reqwest = { workspace = true, optional = true }
+reqwest-drive = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 simd-r-drive = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ members = [
     ".",
     "crates/triplets-core",
     "crates/triplets-debug",
-    "crates/triplets-offline-embedder",
     "crates/triplets-hf-source",
+    "crates/triplets-offline-embedder",
     "crates/triplets-srd-source",
 ]
 resolver = "2"
@@ -65,10 +65,13 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 triplets = { path = ".", version = "0.24.1-alpha" }
 triplets-core = { path = "crates/triplets-core", version = "0.24.1-alpha" }
 triplets-debug = { path = "crates/triplets-debug", version = "0.24.1-alpha" }
-triplets-offline-embedder = { path = "crates/triplets-offline-embedder", version = "0.24.1-alpha" }
 triplets-hf-source = { path = "crates/triplets-hf-source", version = "0.24.1-alpha" }
+triplets-offline-embedder = { path = "crates/triplets-offline-embedder", version = "0.24.1-alpha" }
 triplets-srd-source = { path = "crates/triplets-srd-source", version = "0.24.1-alpha" }
 walkdir = "2.5.0"
+
+[workspace.metadata.cargo-udeps.ignore]
+development = ["triplets-srd-source"]
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     <a href="#epochs-and-determinism">Epochs</a> &middot;
     <a href="#chunking--preprocessing">Chunking &amp; Preprocessing</a> &middot;
     <a href="#ocr--markdown-denoiser">Denoiser</a> &middot;
+    <a href="#offline-teacher-embedding-pre-computation-triplets-offline-embedder">Offline Embedding</a> &middot;
     <a href="#license">License</a>
   </p>
   <p align="center">
@@ -29,7 +30,7 @@ Generate an effectively unlimited stream of [training triplets](https://en.wikip
 
 > A training loop has two halves: the *data side* and the *model side*. `triplets` owns the data side — deterministic and reproducible train/validation/test splitting, seeded shuffling across epochs, weighted multi-source mixing, BM25 hard-negative mining, and static per-record KVP metadata for input conditioning. What it intentionally does *not* include is the model side: forward passes, loss computation, and optimizer steps. The design goal is that you plug this crate's output stream directly into your training framework (crates like [Candle](https://github.com/huggingface/candle), [burn](https://crates.io/crates/burn), [tch](https://crates.io/crates/tch), [PyO3](https://crates.io/crates/pyo3)) and it already handles the parts of the data pipeline that are hardest to get right — correctness, reproducibility, and scale.
 
-**Work in progress.**
+**WORK IN PROGRESS. API MAY BE SUBJECT TO CHANGE.**
 
 ## Overview
 
@@ -417,8 +418,7 @@ hf://org/high-quality-dataset/default/train anchor=query positive=answer weight=
 hf://org/large-corpus/default/train anchor=query positive=answer weight=0.3
 ```
 
-```rust,no_run
-#[cfg(feature = "huggingface")]
+```rust,ignore
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use triplets::{TripletSampler, SplitRatios, DeterministicSplitStore, SplitLabel, Sampler};
     use triplets_hf_source::{load_hf_sources_from_list, resolve_hf_list_roots, build_hf_sources_with_weights};
@@ -1374,6 +1374,22 @@ The list values in the negative column are expanded into individual sections, so
 
 You can also combine user-derived negatives with BM25 mining by registering both a dict source and a standard source — the sampler blends them according to recipe weights and source mixing ratios.
 
+## Offline Teacher Embedding Pre-computation (`triplets-offline-embedder`)
+
+The [`triplets-offline-embedder`](crates/triplets-offline-embedder) crate is an offline data materialization engine for knowledge distillation pipelines. It extracts text from the sampler, executes batch inference against a teacher model, and persists the resulting vectors to per-split stores via the pluggable `EmbedStore` trait.
+
+When used with [`triplets-srd-source`](crates/triplets-srd-source), results are written to [`simd-r-drive`](https://crates.io/crates/simd-r-drive) stores, but any storage backend implementing `EmbedStore` can be substituted. This means knowledge-distilled embeddings can be consumed by downstream pipelines regardless of their source format.
+
+This executes strictly **prior** to the training loop. The student model optimization phase reads these precomputed target embeddings directly from disk, eliminating redundant inference overhead.
+
+**Core Guarantees:**
+
+* **Zero-Copy I/O:** Reads and writes bypass vector cloning via direct memory-mapped slices.
+* **State Resumption:** Automatically opens existing stores and advances the epoch cursor to skip materialized samples.
+* **Interleaved Scheduling:** Balances execution proportionally across train/val splits to prevent temporal dataset skew.
+* **Circuit Breaker:** Enforces a hard pipeline halt if the inference or validation failure rate breaches 5% after the 10-batch warmup window, preventing silent dataset attrition.
+* **Interrupt Safety:** Traps `SIGINT` (Ctrl+C) to guarantee pending split buffers are persisted to disk before process termination.
+
 ## Capabilities
 
 | Capability              | Description                                                                   |
@@ -1386,6 +1402,7 @@ You can also combine user-derived negatives with BM25 mining by registering both
 | **Anti-Shortcut**       | Includes anchor/positive swapping to avoid asymmetric slot bias.              |
 | **OCR & Markdown Denoiser** | Preprocessing step: strips digit-heavy OCR noise and markdown table formatting before chunking. |
 | **User-Derived Negatives** | Supply your own negatives via `negative=` column mapping on HuggingFace dict datasets. |
+| **Offline Embedding** | Offline data materialization engine for knowledge distillation; zero-copy, resumable, circuit-breaker protected. |
 
 ## License
 

--- a/crates/triplets-core/src/sampler/mod.rs
+++ b/crates/triplets-core/src/sampler/mod.rs
@@ -222,7 +222,7 @@ impl<T: Send + 'static> BatchPrefetcher<T> {
         });
         self.stats
             .queued
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
                 Some(value.saturating_sub(1))
             })
             .ok();

--- a/crates/triplets-core/src/sampler/mod.rs
+++ b/crates/triplets-core/src/sampler/mod.rs
@@ -154,6 +154,12 @@ pub trait Sampler {
         split: SplitLabel,
         weights: &HashMap<SourceId, f32>,
     ) -> Result<TripletBatch, SamplerError>;
+    /// Persist sampler and split runtime state for restart-resume.
+    ///
+    /// Default is a no-op, allowing mock/test implementations to skip persistence.
+    fn save_sampler_state(&self, _save_to: Option<&std::path::Path>) -> Result<(), SamplerError> {
+        Ok(())
+    }
 }
 
 /// Background prefetcher that fills a bounded queue with sample batches.
@@ -3170,6 +3176,10 @@ impl<S: SplitStore + EpochStateStore + SamplerStateStore + 'static> Sampler for 
         weights: &HashMap<SourceId, f32>,
     ) -> Result<TripletBatch, SamplerError> {
         self.next_triplet_batch_with_weights_for_split(split, weights)
+    }
+
+    fn save_sampler_state(&self, save_to: Option<&std::path::Path>) -> Result<(), SamplerError> {
+        TripletSampler::save_sampler_state(self, save_to)
     }
 }
 

--- a/crates/triplets-offline-embedder/Cargo.toml
+++ b/crates/triplets-offline-embedder/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "triplets-offline-embedder"
+description = "Offline teacher-embedding precompute pipeline for the triplets data framework."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+categories = ["algorithms", "artificial-intelligence", "science", "text-processing"]
+keywords = [
+    "train-test-split",
+    "triplet-mining",
+    "embedding",
+    "dataset-sampling",
+    "preprocessing",
+]
+
+[dependencies]
+simd-r-drive = { workspace = true }
+triplets-core = { workspace = true }
+triplets-srd-source = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+triplets-offline-embedder = { path = "." }

--- a/crates/triplets-offline-embedder/README.md
+++ b/crates/triplets-offline-embedder/README.md
@@ -1,0 +1,4 @@
+Experimental offline teacher-embedding precompute pipeline for the [triplets](https://crates.io/crates/triplets) data pipeline framework.
+
+For full documentation on configuring sources, sampling, chunking, and pipeline orchestration,
+see the [main triplets README](https://github.com/jzombie/rust-triplets/blob/main/README.md) on GitHub.

--- a/crates/triplets-offline-embedder/src/lib.rs
+++ b/crates/triplets-offline-embedder/src/lib.rs
@@ -8,7 +8,7 @@
 pub mod loop_runner;
 /// High-level orchestration helpers (flush, announce, etc.).
 pub mod orchestration;
-/// [`TripletSampler`] adapter for the [`BatchProvider`] trait.
+/// [`Sampler`](triplets_core::Sampler) adapter for the [`BatchProvider`] trait.
 pub mod sampler_adapter;
 /// Background-thread sampler prefetcher.
 pub mod sampler_prefetcher;

--- a/crates/triplets-offline-embedder/src/lib.rs
+++ b/crates/triplets-offline-embedder/src/lib.rs
@@ -1,0 +1,41 @@
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
+
+//! Interleaved embedding scheduler: fetches batches from a sampler,
+//! embeds them via a callback, and writes results to per-split stores.
+
+/// The interleaved embedding loop.
+pub mod loop_runner;
+/// High-level orchestration helpers (flush, announce, etc.).
+pub mod orchestration;
+/// [`TripletSampler`] adapter for the [`BatchProvider`] trait.
+pub mod sampler_adapter;
+/// Background-thread sampler prefetcher.
+pub mod sampler_prefetcher;
+/// Pure split-scheduling helpers.
+pub mod split_scheduler;
+/// Per-split runtime state and flush logic.
+pub mod split_state;
+/// [`DataStore`](simd_r_drive::storage_engine::DataStore) adapter and split-state initialisation.
+pub mod store_adapter;
+/// Core traits for the offline embedder.
+pub mod traits;
+
+pub use loop_runner::{
+    LoopEvent, LoopHandler, StateSnapshot, compute_split_announcement, run_interleaved_loop,
+};
+pub use orchestration::{flush_all_pending_states, flush_batch, handle_split_exhausted};
+pub use sampler_adapter::SamplerAdapter;
+pub use sampler_prefetcher::{SamplerPrefetcher, filter_pair_batch, filter_triplet_batch};
+pub use split_scheduler::{
+    SplitScheduler, at_sample_limit, compute_deficit_str, compute_global_in_flight,
+    compute_samples_per_sec, is_exhaustion_error, next_split_to_fill, scale_max, should_flush_now,
+    steps_until_next_flush,
+};
+pub use split_state::{EmbedMode, SplitState, flush_pending, validate_embed_response};
+pub use store_adapter::{SrdStoreAdapter, init_split_states_with_batch};
+pub use traits::{
+    BatchProvider, EmbedStore, Embedder, Result, SamplerBatch, SchedulerConfig, SchedulerError,
+    StepResult,
+};
+pub use triplets_core::SplitLabel;

--- a/crates/triplets-offline-embedder/src/loop_runner.rs
+++ b/crates/triplets-offline-embedder/src/loop_runner.rs
@@ -1,0 +1,841 @@
+//! The interleaved embedding loop: picks the most-behind split, fetches a
+//! batch, embeds it, flushes periodically, and reports progress via a
+//! [`LoopHandler`].
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+use triplets_core::SplitLabel;
+
+use crate::orchestration::{flush_all_pending_states, flush_batch, handle_split_exhausted};
+use crate::sampler_prefetcher::SamplerPrefetcher;
+use crate::split_scheduler::SplitScheduler;
+use crate::split_scheduler::{
+    at_sample_limit, compute_deficit_str, compute_global_in_flight, compute_samples_per_sec,
+    is_exhaustion_error, steps_until_next_flush,
+};
+use crate::split_state::SplitState;
+use crate::traits::{BatchProvider, EmbedStore, Embedder, Result, SchedulerConfig};
+
+// ---------------------------------------------------------------------------
+// Event types
+// ---------------------------------------------------------------------------
+
+/// A point-in-time snapshot of a split's counters, for reporting.
+pub struct StateSnapshot {
+    /// Split display name.
+    pub name: &'static str,
+    /// Samples durably written to disk.
+    pub total_written: u64,
+    /// Samples dropped due to embed/validation failures.
+    pub dropped_samples: u64,
+    /// Batches dropped due to embed/validation failures.
+    pub dropped_batches: u64,
+}
+
+/// Events emitted by [`run_interleaved_loop`].
+pub enum LoopEvent {
+    /// The scheduler selected a new split.
+    SplitChange {
+        /// Split display name.
+        name: &'static str,
+        /// Pre-formatted announcement string from the caller.
+        announcement: String,
+    },
+    /// A step completed — progress metrics available.
+    Step {
+        /// Split display name.
+        name: &'static str,
+        /// Current step number.
+        step_num: u64,
+        /// Samples in flight (written + pending).
+        in_flight: u64,
+        /// Target max (0 = unlimited).
+        max: u64,
+        /// Throughput estimate.
+        samples_per_sec: f64,
+        /// Pre-formatted ratio/deficit string from the caller.
+        ratio_str: String,
+        /// Steps until next scheduled flush.
+        steps_until_flush: u64,
+        /// Samples dropped this step (0 if none).
+        dropped: u64,
+    },
+    /// Pending buffer was flushed to disk.
+    BatchFlushed {
+        /// Split name.
+        name: &'static str,
+        /// Flush sequence number.
+        batch_num: u64,
+        /// Number of samples flushed.
+        flushed: u64,
+        /// Total samples written so far.
+        total: u64,
+    },
+    /// Sampler has no more data for this split.
+    Exhausted {
+        /// Split name.
+        name: &'static str,
+    },
+    /// Ctrl+C received — the loop has flushed all pending and is returning.
+    CtrlC {
+        /// Per-split state snapshots at the time of interrupt.
+        states: Vec<StateSnapshot>,
+    },
+    /// The loop finished normally — all splits done.
+    Complete {
+        /// Per-split state snapshots at completion.
+        states: Vec<StateSnapshot>,
+        /// Wall-clock seconds elapsed.
+        elapsed_secs: f64,
+    },
+}
+
+/// Handler for loop events.  Implement this to receive progress and
+/// notification callbacks from [`run_interleaved_loop`].
+pub trait LoopHandler {
+    /// Called when the loop emits an event.
+    fn handle_event(&mut self, event: &LoopEvent);
+}
+
+// ---------------------------------------------------------------------------
+// Announcement helper
+// ---------------------------------------------------------------------------
+
+/// Computes the split-change announcement string.
+///
+/// Call this from your [`LoopHandler`] or before emitting
+/// [`LoopEvent::SplitChange`] to produce the `announcement` field.
+pub fn compute_split_announcement(
+    name: &str,
+    in_flight: u64,
+    max: u64,
+    ratio: f32,
+    ratio_sum: f32,
+    total_in_flight: u64,
+) -> String {
+    let fair_share = if ratio_sum > 0.0 {
+        (total_in_flight as f64 * ratio as f64 / ratio_sum as f64).ceil() as u64
+    } else {
+        0
+    };
+    let deficit = fair_share.saturating_sub(in_flight);
+    let cap_str = if max > 0 {
+        format!("{}/{}", in_flight, max)
+    } else {
+        format!("{} written", in_flight)
+    };
+    let pct = if ratio_sum > 0.0 {
+        ratio as f64 / ratio_sum as f64 * 100.0
+    } else {
+        0.0
+    };
+    if deficit > 0 {
+        format!(
+            "precompute: \u{2500}\u{2500} now filling split [{}] ({}, needs +{deficit} to reach {pct:.0}% target) \u{2500}\u{2500}",
+            name, cap_str,
+        )
+    } else {
+        format!(
+            "precompute: \u{2500}\u{2500} now filling split [{}] ({}, at or ahead of {pct:.0}% target) \u{2500}\u{2500}",
+            name, cap_str,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+/// Run the interleaved embedding loop.
+///
+/// Each iteration the [`SplitScheduler`] picks whichever split is most behind
+/// its proportional target.  The loop fetches a batch from the corresponding
+/// prefetcher, embeds it via `embedder`, and flushes periodically.
+///
+/// Progress and lifecycle events are reported through `handler`.
+///
+/// The loop exits when:
+/// - all splits are exhausted or at their limit, or
+/// - `stop` is set (Ctrl+C) — in this case all pending buffers are flushed
+///   before returning.
+pub fn run_interleaved_loop<S, E, P>(
+    states: &mut [SplitState<S>],
+    prefetchers: &mut HashMap<SplitLabel, SamplerPrefetcher<P>>,
+    embedder: &E,
+    provider: &P,
+    config: &SchedulerConfig,
+    stop: &AtomicBool,
+    handler: &mut dyn LoopHandler,
+) -> Result<()>
+where
+    S: EmbedStore,
+    E: Embedder,
+    P: BatchProvider,
+{
+    let mut scheduler = SplitScheduler::new();
+    let global_start = Instant::now();
+
+    loop {
+        // Recompute in-flight counts every iteration.
+        let labels_vec: Vec<SplitLabel> = states.iter().map(|s| s.label).collect();
+        let counts: Vec<u64> = states
+            .iter()
+            .map(|s| s.total_written + s.pending_anchor_vecs.len() as u64)
+            .collect();
+        let maxes: Vec<u64> = states.iter().map(|s| s.max).collect();
+        let ratios_vec: Vec<f32> = states.iter().map(|s| s.ratio).collect();
+        let exhausted_vec: Vec<bool> = states.iter().map(|s| s.exhausted).collect();
+
+        let Some((label, newly_selected)) =
+            scheduler.next(&labels_vec, &counts, &maxes, &ratios_vec, &exhausted_vec)
+        else {
+            break; // All splits done.
+        };
+
+        if newly_selected {
+            let s = states
+                .iter_mut()
+                .find(|s| s.label == label)
+                .expect("split label not found");
+            s.on_stint_start();
+            debug_assert!(
+                s.pending_anchor_vecs.is_empty(),
+                "pending must be empty when starting a new batch for split {}",
+                s.name,
+            );
+            let in_flight = s.total_written;
+            let total_in_flight: u64 = counts.iter().sum();
+            let ratio_sum: f32 = ratios_vec.iter().sum();
+            let announcement = compute_split_announcement(
+                s.name,
+                in_flight,
+                s.max,
+                s.ratio,
+                ratio_sum,
+                total_in_flight,
+            );
+            handler.handle_event(&LoopEvent::SplitChange {
+                name: s.name,
+                announcement,
+            });
+        }
+
+        let s = states
+            .iter_mut()
+            .find(|s| s.label == label)
+            .expect("split label not found");
+
+        // Fetch next batch from the prefetcher.
+        let batch = match prefetchers
+            .get_mut(&s.label)
+            .expect("prefetcher for split")
+            .next()
+        {
+            Ok(b) => b,
+            Err(e) => {
+                let msg = e.to_string();
+                if is_exhaustion_error(&msg) {
+                    handler.handle_event(&LoopEvent::Exhausted { name: s.name });
+                    handle_split_exhausted(s, provider, &mut scheduler)?;
+                    continue;
+                }
+                return Err(e);
+            }
+        };
+
+        if batch.anchor_texts.is_empty() {
+            handler.handle_event(&LoopEvent::Exhausted { name: s.name });
+            handle_split_exhausted(s, provider, &mut scheduler)?;
+            continue;
+        }
+
+        let step_result = s.step(batch, embedder, config)?;
+
+        let ctrl_c = stop.load(Ordering::Relaxed);
+        let hit_limit = at_sample_limit(s.max, s.total_written, s.pending_anchor_vecs.len() as u64);
+        let should_flush = step_result.should_flush || ctrl_c || hit_limit;
+
+        if should_flush {
+            let flushed_count = flush_batch(s, provider, &mut scheduler)?;
+            if flushed_count > 0 {
+                handler.handle_event(&LoopEvent::BatchFlushed {
+                    name: s.name,
+                    batch_num: s.batch_num,
+                    flushed: flushed_count,
+                    total: s.total_written,
+                });
+            }
+        }
+
+        if ctrl_c {
+            flush_all_pending_states(states, provider)?;
+            let snapshots: Vec<StateSnapshot> = states
+                .iter()
+                .map(|s| StateSnapshot {
+                    name: s.name,
+                    total_written: s.total_written,
+                    dropped_samples: s.dropped_samples,
+                    dropped_batches: s.dropped_batches,
+                })
+                .collect();
+            handler.handle_event(&LoopEvent::CtrlC { states: snapshots });
+            return Ok(());
+        }
+
+        // Progress metrics.
+        let elapsed = s.start.map_or(0.0, |t| t.elapsed().as_secs_f64());
+        let in_flight = s.total_written + s.pending_anchor_vecs.len() as u64;
+        let new_samples = in_flight.saturating_sub(s.segment_base);
+        let samples_per_sec = compute_samples_per_sec(new_samples, elapsed);
+        let steps_until_flush = steps_until_next_flush(s.step_num, config.steps_per_batch);
+
+        let label_pos = labels_vec
+            .iter()
+            .position(|&l| l == label)
+            .expect("split label not found");
+        let global_in_flight = compute_global_in_flight(&counts, label_pos, in_flight);
+        let ratio_sum: f32 = ratios_vec.iter().sum();
+        let ratio_str = compute_deficit_str(in_flight, global_in_flight, s.ratio, ratio_sum);
+
+        handler.handle_event(&LoopEvent::Step {
+            name: s.name,
+            step_num: s.step_num,
+            in_flight,
+            max: s.max,
+            samples_per_sec,
+            ratio_str,
+            steps_until_flush,
+            dropped: step_result.samples_dropped,
+        });
+
+        if hit_limit {
+            s.exhausted = true;
+            scheduler.unlock();
+        }
+    }
+
+    // Post-loop: flush remaining.
+    flush_all_pending_states(states, provider)?;
+    let snapshots: Vec<StateSnapshot> = states
+        .iter()
+        .map(|s| StateSnapshot {
+            name: s.name,
+            total_written: s.total_written,
+            dropped_samples: s.dropped_samples,
+            dropped_batches: s.dropped_batches,
+        })
+        .collect();
+    let elapsed_secs = global_start.elapsed().as_secs_f64();
+    handler.handle_event(&LoopEvent::Complete {
+        states: snapshots,
+        elapsed_secs,
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sampler_prefetcher::SamplerPrefetcher;
+    use crate::split_state::EmbedMode;
+    use crate::traits::{PairWriteArgs, SamplerBatch, SchedulerError, TripletWriteArgs};
+    use std::sync::Arc;
+
+    // -- Mock types --
+
+    struct MockStore;
+
+    impl EmbedStore for MockStore {
+        fn write_pairs(&self, _start_idx: u64, _args: &PairWriteArgs<'_>) -> Result<()> {
+            Ok(())
+        }
+        fn write_triplets(&self, _start_idx: u64, _args: &TripletWriteArgs<'_>) -> Result<()> {
+            Ok(())
+        }
+        fn len(&self) -> Result<u64> {
+            Ok(0)
+        }
+    }
+
+    struct MockEmbedder;
+
+    impl Embedder for MockEmbedder {
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![1.0; 4]).collect())
+        }
+    }
+
+    /// Returns N batches then exhausted.
+    struct MockProvider {
+        batches_remaining: std::sync::atomic::AtomicUsize,
+        save_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl MockProvider {
+        fn new(n: usize) -> Self {
+            Self {
+                batches_remaining: std::sync::atomic::AtomicUsize::new(n),
+                save_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn saves(&self) -> usize {
+            self.save_count.load(Ordering::Relaxed)
+        }
+    }
+
+    impl BatchProvider for MockProvider {
+        fn next_batch(&self, _split: SplitLabel) -> Result<Option<SamplerBatch>> {
+            let remaining = self.batches_remaining.fetch_sub(1, Ordering::Relaxed);
+            if remaining == 0 {
+                return Ok(None);
+            }
+            Ok(Some(SamplerBatch {
+                anchor_texts: vec!["hello".into()],
+                pos_texts: vec!["world".into()],
+                neg_texts: None,
+            }))
+        }
+        fn save_state(&self) -> Result<()> {
+            self.save_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    fn make_state(name: &'static str) -> SplitState<MockStore> {
+        SplitState {
+            label: SplitLabel::Train,
+            name,
+            store: MockStore,
+            mode: EmbedMode::Pair,
+            emb_dim: 4,
+            max: 0,
+            ratio: 1.0,
+            total_written: 0,
+            step_num: 0,
+            batch_num: 0,
+            pending_anchor_vecs: Vec::new(),
+            pending_anchor_texts: Vec::new(),
+            pending_pos_vecs: Vec::new(),
+            pending_pos_texts: Vec::new(),
+            pending_neg_vecs: Vec::new(),
+            pending_neg_texts: Vec::new(),
+            exhausted: false,
+            dropped_batches: 0,
+            total_batches: 0,
+            dropped_samples: 0,
+            start: None,
+            segment_base: 0,
+        }
+    }
+
+    /// Collects all events into a Vec for assertions.
+    struct EventCollector {
+        events: Vec<String>,
+    }
+
+    impl EventCollector {
+        fn new() -> Self {
+            Self { events: Vec::new() }
+        }
+    }
+
+    impl LoopHandler for EventCollector {
+        fn handle_event(&mut self, event: &LoopEvent) {
+            match event {
+                LoopEvent::SplitChange { name, .. } => {
+                    self.events.push(format!("split_change:{name}"));
+                }
+                LoopEvent::Step { name, dropped, .. } => {
+                    if *dropped > 0 {
+                        self.events.push(format!("step:{name}:dropped:{dropped}"));
+                    } else {
+                        self.events.push(format!("step:{name}:ok"));
+                    }
+                }
+                LoopEvent::BatchFlushed { name, flushed, .. } => {
+                    self.events.push(format!("flush:{name}:{flushed}"));
+                }
+                LoopEvent::Exhausted { name } => {
+                    self.events.push(format!("exhausted:{name}"));
+                }
+                LoopEvent::CtrlC { .. } => {
+                    self.events.push("ctrl_c".into());
+                }
+                LoopEvent::Complete { states, .. } => {
+                    let total: u64 = states.iter().map(|s| s.total_written).sum();
+                    self.events.push(format!("complete:{total}"));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn loop_runs_until_exhausted() {
+        let mut states = vec![make_state("train")];
+        let provider = Arc::new(MockProvider::new(3));
+        let embedder = MockEmbedder;
+        let config = SchedulerConfig::new(1, 1, 4, 100);
+
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 2),
+        );
+
+        let stop = AtomicBool::new(false);
+        let mut handler = EventCollector::new();
+
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut handler,
+        )
+        .unwrap();
+
+        assert!(handler.events.iter().any(|e| e.starts_with("exhausted:")));
+        assert!(handler.events.iter().any(|e| e.starts_with("complete:")));
+        // save_state called: 1x on exhaustion (handle_split_exhausted) + 1x on final flush
+        assert!(
+            provider.saves() >= 1,
+            "save_state must be called at least once, got {}",
+            provider.saves()
+        );
+    }
+
+    #[test]
+    fn loop_emits_split_change() {
+        let mut states = vec![make_state("train")];
+        let provider = Arc::new(MockProvider::new(1));
+        let embedder = MockEmbedder;
+        let config = SchedulerConfig::new(1, 1, 4, 100);
+
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 2),
+        );
+
+        let stop = AtomicBool::new(false);
+        let mut handler = EventCollector::new();
+
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut handler,
+        )
+        .unwrap();
+
+        assert!(handler.events.contains(&"split_change:train".into()));
+    }
+
+    #[test]
+    fn loop_stops_on_ctrl_c() {
+        let mut states = vec![make_state("train")];
+        let provider = Arc::new(MockProvider::new(100)); // many batches
+        let embedder = MockEmbedder;
+        let config = SchedulerConfig::new(1, 1, 4, 100);
+
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 2),
+        );
+
+        let stop = AtomicBool::new(true); // pre-set stop flag
+        let mut handler = EventCollector::new();
+
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut handler,
+        )
+        .unwrap();
+
+        assert!(handler.events.contains(&"ctrl_c".into()));
+        // Ctrl+C triggers flush_all_pending_states → save_state
+        assert!(
+            provider.saves() >= 1,
+            "save_state must be called on Ctrl+C, got {}",
+            provider.saves()
+        );
+    }
+
+    #[test]
+    fn compute_split_announcement_formats_correctly() {
+        let msg = compute_split_announcement("train", 50, 100, 0.8, 0.9, 100);
+        assert!(msg.contains("train"));
+        assert!(msg.contains("50/100"));
+    }
+
+    // ------------------------------------------------------------------
+    // Coverage gap tests
+    // ------------------------------------------------------------------
+
+    /// Provider that returns a single empty batch then exhausted.
+    struct EmptyBatchProvider;
+
+    impl BatchProvider for EmptyBatchProvider {
+        fn next_batch(&self, _split: SplitLabel) -> Result<Option<SamplerBatch>> {
+            Ok(Some(SamplerBatch {
+                anchor_texts: vec![],
+                pos_texts: vec![],
+                neg_texts: None,
+            }))
+        }
+        fn save_state(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn loop_handles_empty_batch_from_prefetcher() {
+        let mut states = vec![make_state("train")];
+        let provider = Arc::new(EmptyBatchProvider);
+        let embedder = MockEmbedder;
+        let config = SchedulerConfig::new(1, 1, 4, 100);
+
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 2),
+        );
+
+        let stop = AtomicBool::new(false);
+        let mut handler = EventCollector::new();
+
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut handler,
+        )
+        .unwrap();
+
+        // Empty batch triggers exhaustion path
+        assert!(handler.events.iter().any(|e| e.starts_with("exhausted:")));
+        assert!(handler.events.iter().any(|e| e.starts_with("complete:")));
+    }
+
+    /// Provider that returns a non-exhaustion error.
+    struct ErrorProvider;
+
+    impl BatchProvider for ErrorProvider {
+        fn next_batch(&self, _split: SplitLabel) -> Result<Option<SamplerBatch>> {
+            Err(SchedulerError::Msg("network timeout".into()))
+        }
+        fn save_state(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn loop_returns_non_exhaustion_error() {
+        let mut states = vec![make_state("train")];
+        let provider = Arc::new(ErrorProvider);
+        let embedder = MockEmbedder;
+        let config = SchedulerConfig::new(1, 1, 4, 100);
+
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 2),
+        );
+
+        let stop = AtomicBool::new(false);
+        let mut handler = EventCollector::new();
+
+        let result = run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut handler,
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("network timeout"));
+    }
+
+    /// Provider that returns batches indefinitely for testing hit_limit.
+    struct InfiniteProvider;
+
+    impl BatchProvider for InfiniteProvider {
+        fn next_batch(&self, _split: SplitLabel) -> Result<Option<SamplerBatch>> {
+            Ok(Some(SamplerBatch {
+                anchor_texts: vec!["data".into()],
+                pos_texts: vec!["positive".into()],
+                neg_texts: None,
+            }))
+        }
+        fn save_state(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn loop_marks_split_at_limit_exhausted() {
+        let mut states = vec![make_state("train")];
+        states[0].max = 3; // limit of 3 samples
+
+        let provider = Arc::new(InfiniteProvider);
+        let embedder = MockEmbedder;
+        let config = SchedulerConfig::new(1, 1, 4, 100); // flush every 100 steps
+
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 2),
+        );
+
+        let stop = AtomicBool::new(false);
+        let mut handler = EventCollector::new();
+
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut handler,
+        )
+        .unwrap();
+
+        // Should complete with the split marked at limit
+        assert!(handler.events.iter().any(|e| e.starts_with("complete:")));
+        assert!(states[0].exhausted);
+        assert!(states[0].total_written >= 3);
+    }
+
+    #[test]
+    fn compute_split_announcement_no_limit() {
+        // max=0 means unlimited
+        let msg = compute_split_announcement("val", 100, 0, 0.2, 1.0, 500);
+        assert!(msg.contains("val"));
+        assert!(msg.contains("100 written"));
+        assert!(!msg.contains("/"));
+    }
+
+    #[test]
+    fn compute_split_announcement_deficit_positive() {
+        let msg = compute_split_announcement("train", 10, 200, 0.8, 1.0, 100);
+        assert!(msg.contains("needs"));
+    }
+
+    #[test]
+    fn compute_split_announcement_ratio_sum_zero() {
+        let msg = compute_split_announcement("test", 50, 100, 0.0, 0.0, 100);
+        assert!(msg.contains("test"));
+        assert!(msg.contains("50/100"));
+    }
+
+    #[test]
+    fn save_state_called_at_every_flush_boundary() {
+        // 6 batches, steps_per_batch=2 → flush at steps 2, 4, 6 + exhaustion + final
+        // Verify save_state is called at each flush, not just at the end.
+        let mut states = vec![make_state("train")];
+        let provider = Arc::new(MockProvider::new(6));
+        let embedder = MockEmbedder;
+        let config = SchedulerConfig::new(1, 1, 4, 2); // flush every 2 steps
+
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 2),
+        );
+
+        let stop = AtomicBool::new(false);
+        let mut handler = EventCollector::new();
+
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut handler,
+        )
+        .unwrap();
+
+        let saves = provider.saves();
+        // Expected saves:
+        // - step 2: flush_batch → save_state
+        // - step 4: flush_batch → save_state
+        // - step 6: flush_batch → save_state
+        // - exhaustion: handle_split_exhausted → save_state
+        // - post-loop: flush_all_pending_states → save_state (if pending, else skipped)
+        assert!(
+            saves >= 3,
+            "expected >=3 saves (flush boundaries), got {saves}"
+        );
+
+        // Also verify BatchFlushed events were emitted at the right cadence
+        let flushes: Vec<_> = handler
+            .events
+            .iter()
+            .filter(|e| e.starts_with("flush:"))
+            .collect();
+        assert!(
+            flushes.len() >= 2,
+            "expected >=2 flush events, got {}",
+            flushes.len()
+        );
+    }
+
+    #[test]
+    fn save_state_called_on_ctrl_c_flush() {
+        // Verify save_state is called when Ctrl+C triggers flush_all_pending_states
+        let mut states = vec![make_state("train")];
+        let provider = Arc::new(MockProvider::new(100));
+        let embedder = MockEmbedder;
+        let config = SchedulerConfig::new(1, 1, 4, 100); // large flush interval
+
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 2),
+        );
+
+        let stop = AtomicBool::new(true); // immediate Ctrl+C
+        let mut handler = EventCollector::new();
+
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut handler,
+        )
+        .unwrap();
+
+        assert!(handler.events.contains(&"ctrl_c".into()));
+        assert!(
+            provider.saves() >= 1,
+            "save_state must be called on Ctrl+C, got {}",
+            provider.saves()
+        );
+    }
+}

--- a/crates/triplets-offline-embedder/src/orchestration.rs
+++ b/crates/triplets-offline-embedder/src/orchestration.rs
@@ -1,0 +1,279 @@
+//! High-level orchestration helpers that compose [`flush_pending`],
+//! [`SplitScheduler`], and [`SplitState`] operations.
+
+use crate::split_scheduler::SplitScheduler;
+use crate::split_state::SplitState;
+use crate::split_state::flush_pending;
+use crate::traits::{BatchProvider, EmbedStore, Result};
+
+/// Marks `state` as exhausted, flushes its pending buffer, and unlocks the
+/// scheduler.
+///
+/// Called from both the sampler-error path (`is_exhaustion_error` matched) and
+/// the empty-batch path so both share identical flush+unlock semantics.  The
+/// caller prints the exhaustion message before calling this so the message text
+/// can differ between the two paths.
+pub fn handle_split_exhausted<S: EmbedStore, P: BatchProvider>(
+    state: &mut SplitState<S>,
+    provider: &P,
+    scheduler: &mut SplitScheduler,
+) -> Result<()> {
+    state.exhausted = true;
+    state.batch_num += 1;
+    flush_pending(state, provider)?;
+    scheduler.unlock();
+    Ok(())
+}
+
+/// Performs a scheduled flush: increments `batch_num`, flushes the pending
+/// buffer to disk, unlocks the scheduler, and returns the number of newly
+/// flushed samples.
+pub fn flush_batch<S: EmbedStore, P: BatchProvider>(
+    state: &mut SplitState<S>,
+    provider: &P,
+    scheduler: &mut SplitScheduler,
+) -> Result<u64> {
+    let pre_flush = state.total_written;
+    state.batch_num += 1;
+    flush_pending(state, provider)?;
+    let flushed_count = state.total_written - pre_flush;
+    scheduler.unlock();
+    Ok(flushed_count)
+}
+
+/// Flushes pending buffers for every split that has unflushed data.
+pub fn flush_all_pending_states<S: EmbedStore, P: BatchProvider>(
+    states: &mut [SplitState<S>],
+    provider: &P,
+) -> Result<()> {
+    for s in states.iter_mut() {
+        if !s.pending_anchor_vecs.is_empty() {
+            s.batch_num += 1;
+            flush_pending(s, provider)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::split_state::EmbedMode;
+    use crate::traits::{PairWriteArgs, SamplerBatch, TripletWriteArgs};
+
+    /// Minimal in-memory store for testing.
+    struct MockStore;
+
+    impl EmbedStore for MockStore {
+        fn write_pairs(&self, _start_idx: u64, _args: &PairWriteArgs<'_>) -> Result<()> {
+            Ok(())
+        }
+
+        fn write_triplets(&self, _start_idx: u64, _args: &TripletWriteArgs<'_>) -> Result<()> {
+            Ok(())
+        }
+
+        fn len(&self) -> Result<u64> {
+            Ok(0)
+        }
+    }
+
+    /// Mock batch provider that always returns exhausted.
+    struct MockProvider;
+
+    impl BatchProvider for MockProvider {
+        fn next_batch(&self, _split: triplets_core::SplitLabel) -> Result<Option<SamplerBatch>> {
+            Ok(None)
+        }
+
+        fn save_state(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_test_state() -> SplitState<MockStore> {
+        SplitState {
+            label: triplets_core::SplitLabel::Train,
+            name: "train",
+            store: MockStore,
+            mode: EmbedMode::Pair,
+            emb_dim: 4,
+            max: 0,
+            ratio: 0.8,
+            total_written: 0,
+            step_num: 0,
+            batch_num: 0,
+            pending_anchor_vecs: Vec::new(),
+            pending_anchor_texts: Vec::new(),
+            pending_pos_vecs: Vec::new(),
+            pending_pos_texts: Vec::new(),
+            pending_neg_vecs: Vec::new(),
+            pending_neg_texts: Vec::new(),
+            exhausted: false,
+            dropped_batches: 0,
+            total_batches: 0,
+            dropped_samples: 0,
+            start: None,
+            segment_base: 0,
+        }
+    }
+
+    #[test]
+    fn handle_split_exhausted_marks_and_unlocks() {
+        let mut state = make_test_state();
+        state.pending_anchor_vecs = vec![vec![1.0, 2.0, 3.0, 4.0]];
+        state.pending_anchor_texts = vec!["text".into()];
+        state.pending_pos_vecs = vec![vec![1.0, 2.0, 3.0, 4.0]];
+        state.pending_pos_texts = vec!["text".into()];
+        let provider = MockProvider;
+        let mut scheduler = crate::SplitScheduler::new();
+
+        let _ = scheduler.next(
+            &[triplets_core::SplitLabel::Train],
+            &[0],
+            &[0],
+            &[1.0],
+            &[false],
+        );
+        assert!(scheduler.is_locked());
+
+        handle_split_exhausted(&mut state, &provider, &mut scheduler).unwrap();
+        assert!(state.exhausted);
+        assert!(!scheduler.is_locked());
+    }
+
+    #[test]
+    fn flush_batch_unlocks_scheduler() {
+        let mut state = make_test_state();
+        state.pending_anchor_vecs = vec![vec![1.0; 4]; 3];
+        state.pending_anchor_texts = vec!["a".into(), "b".into(), "c".into()];
+        state.pending_pos_vecs = vec![vec![1.0; 4]; 3];
+        state.pending_pos_texts = vec!["a".into(), "b".into(), "c".into()];
+        let provider = MockProvider;
+        let mut scheduler = crate::SplitScheduler::new();
+
+        let _ = scheduler.next(
+            &[triplets_core::SplitLabel::Train],
+            &[0],
+            &[0],
+            &[1.0],
+            &[false],
+        );
+
+        let count = flush_batch(&mut state, &provider, &mut scheduler).unwrap();
+        assert_eq!(count, 3);
+        assert_eq!(state.batch_num, 1);
+        assert!(!scheduler.is_locked());
+    }
+
+    #[test]
+    fn flush_all_pending_states_flushes_dirty_splits() {
+        let mut states = vec![make_test_state(), make_test_state()];
+        states[0].pending_anchor_vecs = vec![vec![1.0; 4]];
+        states[0].pending_anchor_texts = vec!["x".into()];
+        states[0].pending_pos_vecs = vec![vec![1.0; 4]];
+        states[0].pending_pos_texts = vec!["x".into()];
+        let provider = MockProvider;
+
+        flush_all_pending_states(&mut states, &provider).unwrap();
+        assert_eq!(states[0].batch_num, 1);
+        assert_eq!(states[1].batch_num, 0);
+    }
+
+    #[test]
+    fn handle_split_exhausted_with_pending_flushes_and_unlocks() {
+        let mut state = make_test_state();
+        state.pending_anchor_vecs = vec![vec![1.0; 4], vec![2.0; 4]];
+        state.pending_anchor_texts = vec!["a".into(), "b".into()];
+        state.pending_pos_vecs = vec![vec![3.0; 4], vec![4.0; 4]];
+        state.pending_pos_texts = vec!["c".into(), "d".into()];
+        let provider = MockProvider;
+        let mut scheduler = crate::SplitScheduler::new();
+
+        let _ = scheduler.next(
+            &[triplets_core::SplitLabel::Train],
+            &[0],
+            &[0],
+            &[1.0],
+            &[false],
+        );
+        assert!(scheduler.is_locked());
+
+        handle_split_exhausted(&mut state, &provider, &mut scheduler).unwrap();
+        assert!(state.exhausted);
+        assert!(!scheduler.is_locked());
+        assert!(state.is_pending_empty());
+        assert_eq!(state.total_written, 2); // flushed 2 pending
+        assert_eq!(state.batch_num, 1);
+    }
+
+    #[test]
+    fn flush_batch_with_pending_returns_count() {
+        let mut state = make_test_state();
+        state.pending_anchor_vecs = vec![vec![1.0; 4]; 5];
+        state.pending_anchor_texts = vec!["a".into(); 5];
+        state.pending_pos_vecs = vec![vec![2.0; 4]; 5];
+        state.pending_pos_texts = vec!["b".into(); 5];
+        let provider = MockProvider;
+        let mut scheduler = crate::SplitScheduler::new();
+
+        let _ = scheduler.next(
+            &[triplets_core::SplitLabel::Train],
+            &[0],
+            &[0],
+            &[1.0],
+            &[false],
+        );
+
+        let count = flush_batch(&mut state, &provider, &mut scheduler).unwrap();
+        assert_eq!(count, 5);
+        assert_eq!(state.total_written, 5);
+        assert!(state.is_pending_empty());
+        assert!(!scheduler.is_locked());
+    }
+
+    #[test]
+    fn flush_batch_empty_pending_returns_zero() {
+        let mut state = make_test_state();
+        // No pending data
+        let provider = MockProvider;
+        let mut scheduler = crate::SplitScheduler::new();
+
+        let count = flush_batch(&mut state, &provider, &mut scheduler).unwrap();
+        assert_eq!(count, 0);
+        assert_eq!(state.total_written, 0);
+        assert!(!scheduler.is_locked());
+    }
+
+    #[test]
+    fn flush_all_pending_multiple_dirty_states() {
+        let mut states = vec![make_test_state(), make_test_state(), make_test_state()];
+
+        // State 0: 3 pending
+        states[0].pending_anchor_vecs = vec![vec![1.0; 4]; 3];
+        states[0].pending_anchor_texts = vec!["a".into(); 3];
+        states[0].pending_pos_vecs = vec![vec![2.0; 4]; 3];
+        states[0].pending_pos_texts = vec!["b".into(); 3];
+
+        // State 1: clean
+        // State 2: 2 pending
+        states[2].pending_anchor_vecs = vec![vec![3.0; 4]; 2];
+        states[2].pending_anchor_texts = vec!["c".into(); 2];
+        states[2].pending_pos_vecs = vec![vec![4.0; 4]; 2];
+        states[2].pending_pos_texts = vec!["d".into(); 2];
+
+        let provider = MockProvider;
+        flush_all_pending_states(&mut states, &provider).unwrap();
+
+        assert_eq!(states[0].batch_num, 1);
+        assert_eq!(states[0].total_written, 3);
+        assert!(states[0].is_pending_empty());
+
+        assert_eq!(states[1].batch_num, 0);
+        assert_eq!(states[1].total_written, 0);
+
+        assert_eq!(states[2].batch_num, 1);
+        assert_eq!(states[2].total_written, 2);
+        assert!(states[2].is_pending_empty());
+    }
+}

--- a/crates/triplets-offline-embedder/src/sampler_adapter.rs
+++ b/crates/triplets-offline-embedder/src/sampler_adapter.rs
@@ -1,4 +1,4 @@
-//! Adapter bridging a [`Sampler`] trait object to the [`BatchProvider`] trait.
+//! Adapter bridging a [`Sampler`](triplets_core::Sampler) trait object to the [`BatchProvider`] trait.
 
 use std::sync::Arc;
 
@@ -9,7 +9,7 @@ use crate::sampler_prefetcher::{filter_pair_batch, filter_triplet_batch};
 use crate::traits::{BatchProvider, Result, SamplerBatch, SchedulerError};
 
 /// Adapter that routes batch-fetching calls to a [`Sampler`] trait object
-/// and converts the core [`SampleBatch`] / [`TripletBatch`] types into the
+/// and converts the core [`SampleBatch`](triplets_core::data::SampleBatch) / [`TripletBatch`](triplets_core::data::TripletBatch) types into the
 /// scheduler's [`SamplerBatch`].
 pub struct SamplerAdapter {
     /// The underlying sampler (trait object for testability).

--- a/crates/triplets-offline-embedder/src/sampler_adapter.rs
+++ b/crates/triplets-offline-embedder/src/sampler_adapter.rs
@@ -1,0 +1,323 @@
+//! Adapter bridging a [`Sampler`] trait object to the [`BatchProvider`] trait.
+
+use std::sync::Arc;
+
+use triplets_core::{Sampler, SplitLabel};
+use triplets_srd_source::srd_triplet::SrdMode;
+
+use crate::sampler_prefetcher::{filter_pair_batch, filter_triplet_batch};
+use crate::traits::{BatchProvider, Result, SamplerBatch, SchedulerError};
+
+/// Adapter that routes batch-fetching calls to a [`Sampler`] trait object
+/// and converts the core [`SampleBatch`] / [`TripletBatch`] types into the
+/// scheduler's [`SamplerBatch`].
+pub struct SamplerAdapter {
+    /// The underlying sampler (trait object for testability).
+    pub sampler: Arc<dyn Sampler + Send + Sync>,
+    /// Pair or triplet output mode.
+    pub mode: SrdMode,
+}
+
+impl BatchProvider for SamplerAdapter {
+    fn next_batch(&self, split: SplitLabel) -> Result<Option<SamplerBatch>> {
+        match self.mode {
+            SrdMode::Pair => {
+                let batch = self
+                    .sampler
+                    .next_pair_batch(split)
+                    .map_err(|e| SchedulerError::Msg(format!("sampler error: {e}")))?;
+                if batch.pairs.is_empty() {
+                    return Ok(None);
+                }
+                let (anchor_texts, pos_texts) = filter_pair_batch(&batch.pairs);
+                if anchor_texts.is_empty() {
+                    return Ok(None);
+                }
+                Ok(Some(SamplerBatch {
+                    anchor_texts,
+                    pos_texts,
+                    neg_texts: None,
+                }))
+            }
+            SrdMode::Triplet => {
+                let batch = self
+                    .sampler
+                    .next_triplet_batch(split)
+                    .map_err(|e| SchedulerError::Msg(format!("sampler error: {e}")))?;
+                if batch.triplets.is_empty() {
+                    return Ok(None);
+                }
+                let (anchor_texts, pos_texts, neg_texts) = filter_triplet_batch(&batch.triplets);
+                if anchor_texts.is_empty() {
+                    return Ok(None);
+                }
+                Ok(Some(SamplerBatch {
+                    anchor_texts,
+                    pos_texts,
+                    neg_texts: Some(neg_texts),
+                }))
+            }
+        }
+    }
+
+    fn save_state(&self) -> Result<()> {
+        self.sampler
+            .save_sampler_state(None)
+            .map_err(|e| SchedulerError::Msg(format!("save state error: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use triplets_core::data::{
+        ChunkView, PairLabel, QualityScore, RecordChunk, SampleBatch, SamplePair, SampleTriplet,
+        TripletBatch,
+    };
+    use triplets_core::{SamplerError, SourceId};
+
+    fn make_chunk(text: &str) -> RecordChunk {
+        RecordChunk {
+            record_id: "r1".into(),
+            section_idx: 0,
+            view: ChunkView::Window {
+                index: 0,
+                overlap: 0,
+                span: 10,
+            },
+            text: text.to_string(),
+            tokens_estimate: 1,
+            quality: QualityScore::default(),
+            kvp_meta: Default::default(),
+        }
+    }
+
+    struct MockSampler {
+        pair_batch: Option<SampleBatch>,
+        triplet_batch: Option<TripletBatch>,
+        save_called: std::sync::atomic::AtomicBool,
+    }
+
+    impl MockSampler {
+        fn new() -> Self {
+            Self {
+                pair_batch: Some(SampleBatch {
+                    pairs: vec![
+                        SamplePair {
+                            recipe: "test".into(),
+                            anchor: make_chunk("anchor_1"),
+                            positive: make_chunk("pos_1"),
+                            weight: 1.0,
+                            instruction: None,
+                            label: PairLabel::Positive,
+                            reason: None,
+                        },
+                        SamplePair {
+                            recipe: "test".into(),
+                            anchor: make_chunk("anchor_2"),
+                            positive: make_chunk("pos_2"),
+                            weight: 1.0,
+                            instruction: None,
+                            label: PairLabel::Positive,
+                            reason: None,
+                        },
+                    ],
+                }),
+                triplet_batch: Some(TripletBatch {
+                    triplets: vec![SampleTriplet {
+                        recipe: "test".into(),
+                        anchor: make_chunk("t_anchor"),
+                        positive: make_chunk("t_pos"),
+                        negative: make_chunk("t_neg"),
+                        weight: 1.0,
+                        instruction: None,
+                    }],
+                }),
+                save_called: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        fn with_empty_pairs() -> Self {
+            let mut s = Self::new();
+            s.pair_batch = Some(SampleBatch { pairs: vec![] });
+            s
+        }
+
+        fn with_empty_triplets() -> Self {
+            let mut s = Self::new();
+            s.triplet_batch = Some(TripletBatch { triplets: vec![] });
+            s
+        }
+    }
+
+    impl Sampler for MockSampler {
+        fn next_pair_batch(
+            &self,
+            _split: SplitLabel,
+        ) -> std::result::Result<SampleBatch, SamplerError> {
+            self.pair_batch
+                .clone()
+                .ok_or(SamplerError::SourceUnavailable {
+                    source_id: "mock".into(),
+                    reason: "empty".into(),
+                })
+        }
+
+        fn next_triplet_batch(
+            &self,
+            _split: SplitLabel,
+        ) -> std::result::Result<TripletBatch, SamplerError> {
+            self.triplet_batch
+                .clone()
+                .ok_or(SamplerError::SourceUnavailable {
+                    source_id: "mock".into(),
+                    reason: "empty".into(),
+                })
+        }
+
+        fn next_pair_batch_with_weights(
+            &self,
+            split: SplitLabel,
+            _weights: &HashMap<SourceId, f32>,
+        ) -> std::result::Result<SampleBatch, SamplerError> {
+            self.next_pair_batch(split)
+        }
+
+        fn next_text_batch_with_weights(
+            &self,
+            _split: SplitLabel,
+            _weights: &HashMap<SourceId, f32>,
+        ) -> std::result::Result<triplets_core::data::TextBatch, SamplerError> {
+            unimplemented!()
+        }
+
+        fn next_triplet_batch_with_weights(
+            &self,
+            split: SplitLabel,
+            _weights: &HashMap<SourceId, f32>,
+        ) -> std::result::Result<TripletBatch, SamplerError> {
+            self.next_triplet_batch(split)
+        }
+
+        fn save_sampler_state(
+            &self,
+            _save_to: Option<&std::path::Path>,
+        ) -> std::result::Result<(), SamplerError> {
+            self.save_called
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn adapter_returns_pair_batch() {
+        let adapter = SamplerAdapter {
+            sampler: Arc::new(MockSampler::new()),
+            mode: SrdMode::Pair,
+        };
+        let batch = adapter.next_batch(SplitLabel::Train).unwrap();
+        let batch = batch.expect("should have batch");
+        assert_eq!(batch.anchor_texts, vec!["anchor_1", "anchor_2"]);
+        assert_eq!(batch.pos_texts, vec!["pos_1", "pos_2"]);
+        assert!(batch.neg_texts.is_none());
+    }
+
+    #[test]
+    fn adapter_returns_triplet_batch() {
+        let adapter = SamplerAdapter {
+            sampler: Arc::new(MockSampler::new()),
+            mode: SrdMode::Triplet,
+        };
+        let batch = adapter.next_batch(SplitLabel::Train).unwrap();
+        let batch = batch.expect("should have batch");
+        assert_eq!(batch.anchor_texts, vec!["t_anchor"]);
+        assert_eq!(batch.pos_texts, vec!["t_pos"]);
+        assert_eq!(batch.neg_texts, Some(vec!["t_neg".to_string()]));
+    }
+
+    #[test]
+    fn adapter_returns_none_on_empty_pairs() {
+        let adapter = SamplerAdapter {
+            sampler: Arc::new(MockSampler::with_empty_pairs()),
+            mode: SrdMode::Pair,
+        };
+        let batch = adapter.next_batch(SplitLabel::Train).unwrap();
+        assert!(batch.is_none());
+    }
+
+    #[test]
+    fn adapter_returns_none_on_empty_triplets() {
+        let adapter = SamplerAdapter {
+            sampler: Arc::new(MockSampler::with_empty_triplets()),
+            mode: SrdMode::Triplet,
+        };
+        let batch = adapter.next_batch(SplitLabel::Train).unwrap();
+        assert!(batch.is_none());
+    }
+
+    #[test]
+    fn adapter_save_state_delegates_to_sampler() {
+        let mock = MockSampler::new();
+        let adapter = SamplerAdapter {
+            sampler: Arc::new(mock),
+            mode: SrdMode::Pair,
+        };
+        adapter.save_state().unwrap();
+        // The mock's save_called would be true if we could access it,
+        // but since it's behind Arc<dyn Sampler> we just verify no error.
+    }
+
+    #[test]
+    fn adapter_propagates_sampler_error() {
+        struct FailingSampler;
+        impl Sampler for FailingSampler {
+            fn next_pair_batch(
+                &self,
+                _split: SplitLabel,
+            ) -> std::result::Result<SampleBatch, SamplerError> {
+                Err(SamplerError::SourceUnavailable {
+                    source_id: "fail".into(),
+                    reason: "intentional".into(),
+                })
+            }
+            fn next_triplet_batch(
+                &self,
+                _split: SplitLabel,
+            ) -> std::result::Result<TripletBatch, SamplerError> {
+                Err(SamplerError::SourceUnavailable {
+                    source_id: "fail".into(),
+                    reason: "intentional".into(),
+                })
+            }
+            fn next_pair_batch_with_weights(
+                &self,
+                _split: SplitLabel,
+                _w: &HashMap<SourceId, f32>,
+            ) -> std::result::Result<SampleBatch, SamplerError> {
+                self.next_pair_batch(_split)
+            }
+            fn next_text_batch_with_weights(
+                &self,
+                _split: SplitLabel,
+                _w: &HashMap<SourceId, f32>,
+            ) -> std::result::Result<triplets_core::data::TextBatch, SamplerError> {
+                unimplemented!()
+            }
+            fn next_triplet_batch_with_weights(
+                &self,
+                _split: SplitLabel,
+                _w: &HashMap<SourceId, f32>,
+            ) -> std::result::Result<TripletBatch, SamplerError> {
+                self.next_triplet_batch(_split)
+            }
+        }
+
+        let adapter = SamplerAdapter {
+            sampler: Arc::new(FailingSampler),
+            mode: SrdMode::Pair,
+        };
+        let err = adapter.next_batch(SplitLabel::Train).unwrap_err();
+        assert!(err.to_string().contains("sampler error"));
+    }
+}

--- a/crates/triplets-offline-embedder/src/sampler_prefetcher.rs
+++ b/crates/triplets-offline-embedder/src/sampler_prefetcher.rs
@@ -1,0 +1,444 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+
+use triplets_core::SplitLabel;
+use triplets_core::data::{SamplePair, SampleTriplet};
+
+use crate::split_scheduler::is_exhaustion_error;
+use crate::traits::{BatchProvider, Result, SamplerBatch, SchedulerError};
+
+/// Jointly filter a pair batch: skip any pair where EITHER text is empty
+/// so anchor and positive vectors always have the same length.
+pub fn filter_pair_batch(pairs: &[SamplePair]) -> (Vec<String>, Vec<String>) {
+    pairs
+        .iter()
+        .filter(|p| !p.anchor.text.is_empty() && !p.positive.text.is_empty())
+        .map(|p| (p.anchor.text.clone(), p.positive.text.clone()))
+        .unzip()
+}
+
+/// Jointly filter a triplet batch: skip any triplet where ANY text is empty
+/// so anchor, positive, and negative vectors always have the same length.
+pub fn filter_triplet_batch(triplets: &[SampleTriplet]) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let triples: Vec<_> = triplets
+        .iter()
+        .filter(|t| {
+            !t.anchor.text.is_empty() && !t.positive.text.is_empty() && !t.negative.text.is_empty()
+        })
+        .map(|t| {
+            (
+                t.anchor.text.clone(),
+                t.positive.text.clone(),
+                t.negative.text.clone(),
+            )
+        })
+        .collect();
+    let anchor = triples.iter().map(|(a, _, _)| a.clone()).collect();
+    let pos = triples.iter().map(|(_, p, _)| p.clone()).collect();
+    let neg = triples.iter().map(|(_, _, n)| n.clone()).collect();
+    (anchor, pos, neg)
+}
+
+/// Background-thread prefetcher that calls the sampler's pair or triplet API
+/// in a background thread, sending batches through a bounded channel.
+pub struct SamplerPrefetcher<P: BatchProvider + 'static> {
+    rx: Option<mpsc::Receiver<Result<SamplerBatch>>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
+    _provider: std::sync::Arc<P>,
+}
+
+impl<P: BatchProvider + 'static> SamplerPrefetcher<P> {
+    /// Spawn a background prefetcher thread.
+    ///
+    /// * `provider` — the batch provider (must be `Send + Sync + 'static`).
+    /// * `split` — which split to prefetch batches for.
+    /// * `queue_cap` — max buffered batches (back-pressure, at least 1).
+    pub fn new(provider: Arc<P>, split: SplitLabel, queue_cap: usize) -> Self {
+        let (tx, rx) = mpsc::sync_channel(queue_cap.max(1));
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_clone = Arc::clone(&stop);
+        let provider_clone = Arc::clone(&provider);
+
+        let handle = std::thread::Builder::new()
+            .name(format!("sampler-prefetch-{split:?}"))
+            .spawn(move || {
+                loop {
+                    if stop_clone.load(Ordering::Relaxed) {
+                        break;
+                    }
+
+                    match provider_clone.next_batch(split) {
+                        Ok(Some(batch)) => {
+                            if batch.anchor_texts.is_empty() {
+                                let _ = tx.send(Err(SchedulerError::Msg("exhausted".into())));
+                                break;
+                            }
+                            if tx.send(Ok(batch)).is_err() {
+                                break;
+                            }
+                        }
+                        Ok(None) => {
+                            let _ = tx.send(Err(SchedulerError::Msg("exhausted".into())));
+                            break;
+                        }
+                        Err(e) => {
+                            let msg = e.to_string();
+                            if is_exhaustion_error(&msg) {
+                                let _ = tx.send(Err(SchedulerError::Msg("exhausted".into())));
+                            } else {
+                                let _ = tx.send(Err(e));
+                            }
+                            break;
+                        }
+                    }
+                }
+            })
+            .expect("spawn sampler prefetcher");
+
+        Self {
+            rx: Some(rx),
+            handle: Some(handle),
+            stop,
+            _provider: provider,
+        }
+    }
+
+    /// Pop the next prefetched batch (blocking if none are ready yet).
+    pub fn next(&self) -> Result<SamplerBatch> {
+        let rx = self
+            .rx
+            .as_ref()
+            .ok_or_else(|| SchedulerError::Msg("sampler prefetcher stopped".into()))?;
+        match rx.recv() {
+            Ok(Ok(batch)) => Ok(batch),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(SchedulerError::Msg(
+                "sampler prefetcher channel closed".into(),
+            )),
+        }
+    }
+}
+
+impl<P: BatchProvider + 'static> Drop for SamplerPrefetcher<P> {
+    fn drop(&mut self) {
+        // 1. Signal the background thread to stop.
+        self.stop.store(true, Ordering::Relaxed);
+        // 2. Drop receiver to unblock any pending send() in the background thread.
+        self.rx.take();
+        // 3. Join the thread — unwrap to propagate panics from the background thread.
+        //    A panicked worker indicates a fatal pipeline state (OOM, provider panic).
+        if let Some(handle) = self.handle.take() {
+            handle.join().unwrap();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use triplets_core::data::{ChunkView, PairLabel, QualityScore, RecordChunk};
+
+    fn make_chunk(text: &str) -> RecordChunk {
+        RecordChunk {
+            record_id: "r1".into(),
+            section_idx: 0,
+            view: ChunkView::Window {
+                index: 0,
+                overlap: 0,
+                span: 10,
+            },
+            text: text.to_string(),
+            tokens_estimate: 1,
+            quality: QualityScore::default(),
+            kvp_meta: Default::default(),
+        }
+    }
+
+    struct MockProvider {
+        batches: std::sync::Mutex<Vec<SamplerBatch>>,
+        call_count: AtomicUsize,
+    }
+
+    impl MockProvider {
+        fn new(batches: Vec<SamplerBatch>) -> Self {
+            Self {
+                batches: std::sync::Mutex::new(batches),
+                call_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl BatchProvider for MockProvider {
+        fn next_batch(&self, _split: SplitLabel) -> Result<Option<SamplerBatch>> {
+            let idx = self.call_count.fetch_add(1, Ordering::Relaxed);
+            let mut batches = self.batches.lock().unwrap();
+            if idx < batches.len() {
+                Ok(Some(batches.remove(0)))
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn save_state(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn filter_pair_batch_skips_empty() {
+        let pairs = vec![
+            SamplePair {
+                recipe: "test".into(),
+                anchor: make_chunk("hello"),
+                positive: make_chunk("world"),
+                weight: 1.0,
+                instruction: None,
+                label: PairLabel::Positive,
+                reason: None,
+            },
+            SamplePair {
+                recipe: "test".into(),
+                anchor: make_chunk(""),
+                positive: make_chunk("world"),
+                weight: 1.0,
+                instruction: None,
+                label: PairLabel::Positive,
+                reason: None,
+            },
+        ];
+        let (anchors, positions) = filter_pair_batch(&pairs);
+        assert_eq!(anchors, vec!["hello"]);
+        assert_eq!(positions, vec!["world"]);
+    }
+
+    #[test]
+    fn filter_triplet_batch_skips_empty() {
+        let triplets = vec![
+            SampleTriplet {
+                recipe: "test".into(),
+                anchor: make_chunk("a"),
+                positive: make_chunk("p"),
+                negative: make_chunk("n"),
+                weight: 1.0,
+                instruction: None,
+            },
+            SampleTriplet {
+                recipe: "test".into(),
+                anchor: make_chunk("a2"),
+                positive: make_chunk(""),
+                negative: make_chunk("n2"),
+                weight: 1.0,
+                instruction: None,
+            },
+        ];
+        let (anchors, positions, negatives) = filter_triplet_batch(&triplets);
+        assert_eq!(anchors, vec!["a"]);
+        assert_eq!(positions, vec!["p"]);
+        assert_eq!(negatives, vec!["n"]);
+    }
+
+    #[test]
+    fn prefetcher_returns_batches_then_exhausted() {
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a".into()],
+            pos_texts: vec!["p".into()],
+            neg_texts: None,
+        };
+        let provider = Arc::new(MockProvider::new(vec![batch]));
+        let prefetcher = SamplerPrefetcher::new(provider, SplitLabel::Train, 4);
+
+        let result = prefetcher.next().unwrap();
+        assert_eq!(result.anchor_texts, vec!["a"]);
+
+        let err = prefetcher.next().unwrap_err();
+        assert!(err.to_string().contains("exhausted"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Additional filter_pair_batch tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_pair_batch_skips_empty_positive() {
+        let pairs = vec![SamplePair {
+            recipe: "test".into(),
+            anchor: make_chunk("a1"),
+            positive: make_chunk(""),
+            weight: 1.0,
+            instruction: None,
+            label: PairLabel::Positive,
+            reason: None,
+        }];
+        let (anchors, positions) = filter_pair_batch(&pairs);
+        assert!(anchors.is_empty());
+        assert!(positions.is_empty());
+    }
+
+    #[test]
+    fn filter_pair_batch_skips_both_empty() {
+        let pairs = vec![SamplePair {
+            recipe: "test".into(),
+            anchor: make_chunk(""),
+            positive: make_chunk(""),
+            weight: 1.0,
+            instruction: None,
+            label: PairLabel::Positive,
+            reason: None,
+        }];
+        let (anchors, positions) = filter_pair_batch(&pairs);
+        assert!(anchors.is_empty());
+        assert!(positions.is_empty());
+    }
+
+    #[test]
+    fn filter_pair_batch_keeps_all_nonempty() {
+        let pairs = vec![
+            SamplePair {
+                recipe: "test".into(),
+                anchor: make_chunk("a1"),
+                positive: make_chunk("p1"),
+                weight: 1.0,
+                instruction: None,
+                label: PairLabel::Positive,
+                reason: None,
+            },
+            SamplePair {
+                recipe: "test".into(),
+                anchor: make_chunk("a2"),
+                positive: make_chunk("p2"),
+                weight: 1.0,
+                instruction: None,
+                label: PairLabel::Positive,
+                reason: None,
+            },
+        ];
+        let (anchors, positions) = filter_pair_batch(&pairs);
+        assert_eq!(anchors, vec!["a1", "a2"]);
+        assert_eq!(positions, vec!["p1", "p2"]);
+    }
+
+    #[test]
+    fn filter_pair_batch_empty_input() {
+        let pairs: Vec<SamplePair> = vec![];
+        let (anchors, positions) = filter_pair_batch(&pairs);
+        assert!(anchors.is_empty());
+        assert!(positions.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Additional filter_triplet_batch tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_triplet_batch_skips_empty_positive() {
+        let triplets = vec![SampleTriplet {
+            recipe: "test".into(),
+            anchor: make_chunk("a"),
+            positive: make_chunk(""),
+            negative: make_chunk("n"),
+            weight: 1.0,
+            instruction: None,
+        }];
+        let (anchors, positions, negatives) = filter_triplet_batch(&triplets);
+        assert!(anchors.is_empty());
+        assert!(positions.is_empty());
+        assert!(negatives.is_empty());
+    }
+
+    #[test]
+    fn filter_triplet_batch_skips_empty_negative() {
+        let triplets = vec![SampleTriplet {
+            recipe: "test".into(),
+            anchor: make_chunk("a"),
+            positive: make_chunk("p"),
+            negative: make_chunk(""),
+            weight: 1.0,
+            instruction: None,
+        }];
+        let (anchors, positions, negatives) = filter_triplet_batch(&triplets);
+        assert!(anchors.is_empty());
+        assert!(positions.is_empty());
+        assert!(negatives.is_empty());
+    }
+
+    #[test]
+    fn filter_triplet_batch_skips_all_empty() {
+        let triplets = vec![SampleTriplet {
+            recipe: "test".into(),
+            anchor: make_chunk(""),
+            positive: make_chunk(""),
+            negative: make_chunk(""),
+            weight: 1.0,
+            instruction: None,
+        }];
+        let (anchors, positions, negatives) = filter_triplet_batch(&triplets);
+        assert!(anchors.is_empty());
+        assert!(positions.is_empty());
+        assert!(negatives.is_empty());
+    }
+
+    #[test]
+    fn filter_triplet_batch_keeps_all_nonempty() {
+        let triplets = vec![
+            SampleTriplet {
+                recipe: "test".into(),
+                anchor: make_chunk("a1"),
+                positive: make_chunk("p1"),
+                negative: make_chunk("n1"),
+                weight: 1.0,
+                instruction: None,
+            },
+            SampleTriplet {
+                recipe: "test".into(),
+                anchor: make_chunk("a2"),
+                positive: make_chunk("p2"),
+                negative: make_chunk("n2"),
+                weight: 1.0,
+                instruction: None,
+            },
+        ];
+        let (anchors, positions, negatives) = filter_triplet_batch(&triplets);
+        assert_eq!(anchors, vec!["a1", "a2"]);
+        assert_eq!(positions, vec!["p1", "p2"]);
+        assert_eq!(negatives, vec!["n1", "n2"]);
+    }
+
+    #[test]
+    fn filter_triplet_batch_empty_input() {
+        let triplets: Vec<SampleTriplet> = vec![];
+        let (anchors, positions, negatives) = filter_triplet_batch(&triplets);
+        assert!(anchors.is_empty());
+        assert!(positions.is_empty());
+        assert!(negatives.is_empty());
+    }
+
+    #[test]
+    fn prefetcher_drop_joins_thread() {
+        use std::time::Duration;
+
+        // Provider that returns 3 batches then exhausted.
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a".into()],
+            pos_texts: vec!["p".into()],
+            neg_texts: None,
+        };
+        let provider = Arc::new(MockProvider::new(vec![batch.clone(), batch.clone(), batch]));
+        let prefetcher = SamplerPrefetcher::new(provider, SplitLabel::Train, 4);
+
+        // Consume one batch so the background thread is mid-work.
+        let _ = prefetcher.next();
+
+        // Drop the prefetcher — must complete within 1 second if thread is joined.
+        let start = std::time::Instant::now();
+        drop(prefetcher);
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "prefetcher drop took {elapsed:?} — thread may not have been joined"
+        );
+    }
+}

--- a/crates/triplets-offline-embedder/src/split_scheduler.rs
+++ b/crates/triplets-offline-embedder/src/split_scheduler.rs
@@ -1,0 +1,354 @@
+use triplets_core::SplitLabel;
+
+/// Choose the split most behind its proportional target.
+///
+/// Returns `None` when every split is exhausted or at its limit.
+pub fn next_split_to_fill(
+    labels: &[SplitLabel],
+    counts: &[u64],
+    maxes: &[u64],
+    ratios: &[f32],
+    exhausted: &[bool],
+) -> Option<SplitLabel> {
+    debug_assert_eq!(labels.len(), counts.len());
+    debug_assert_eq!(counts.len(), maxes.len());
+    debug_assert_eq!(counts.len(), ratios.len());
+    debug_assert_eq!(counts.len(), exhausted.len());
+
+    let mut best: Option<(SplitLabel, f64)> = None;
+    for i in 0..counts.len() {
+        if exhausted[i] {
+            continue;
+        }
+        if maxes[i] > 0 && counts[i] >= maxes[i] {
+            continue;
+        }
+        let fullness = if ratios[i] > 0.0 {
+            counts[i] as f64 / ratios[i] as f64
+        } else {
+            f64::MAX
+        };
+        match best {
+            None => best = Some((labels[i], fullness)),
+            Some((_, best_fullness)) if fullness < best_fullness => {
+                best = Some((labels[i], fullness))
+            }
+            _ => {}
+        }
+    }
+    best.map(|(label, _)| label)
+}
+
+/// Batch-locking split scheduler.
+///
+/// Wraps the `active_label` / `next_split_to_fill` state machine so it can be
+/// tested independently of the main loop.
+///
+/// **Contract:** `unlock()` must be called after every flush and after marking
+/// a split exhausted or at its limit.  Until `unlock()` is called the same
+/// split label is returned on every call to `next()`.
+pub struct SplitScheduler {
+    active_label: Option<SplitLabel>,
+}
+
+impl SplitScheduler {
+    /// Create a new scheduler with no active split.
+    pub fn new() -> Self {
+        Self { active_label: None }
+    }
+
+    /// Return the split that should receive the next embed step.
+    ///
+    /// * `newly_selected == true`  — the split was just chosen at a batch
+    ///   boundary; the caller should print the announcement banner.
+    /// * `newly_selected == false` — continuing an in-progress batch; no
+    ///   announcement needed.
+    ///
+    /// Returns `None` when every split is exhausted or at its limit.
+    pub fn next(
+        &mut self,
+        labels: &[SplitLabel],
+        counts: &[u64],
+        maxes: &[u64],
+        ratios: &[f32],
+        exhausted: &[bool],
+    ) -> Option<(SplitLabel, bool)> {
+        if let Some(label) = self.active_label {
+            Some((label, false))
+        } else {
+            let label = next_split_to_fill(labels, counts, maxes, ratios, exhausted)?;
+            self.active_label = Some(label);
+            Some((label, true))
+        }
+    }
+
+    /// Release the lock so the next call to `next()` re-evaluates the split.
+    pub fn unlock(&mut self) {
+        self.active_label = None;
+    }
+
+    /// Returns `true` when a split is currently locked (i.e. `next()` would
+    /// return the same split without re-evaluating).
+    pub fn is_locked(&self) -> bool {
+        self.active_label.is_some()
+    }
+}
+
+impl Default for SplitScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Computes the number of steps remaining until the next scheduled flush.
+///
+/// The flush cadence is every `steps_per_batch` steps.  Returns a value in
+/// `[1, steps_per_batch]`.
+pub fn steps_until_next_flush(step_num: u64, steps_per_batch: u64) -> u64 {
+    steps_per_batch - (step_num % steps_per_batch)
+}
+
+/// Computes the instantaneous throughput for the current stint.
+pub fn compute_samples_per_sec(new_samples: u64, elapsed_secs: f64) -> f64 {
+    if elapsed_secs > 0.0 {
+        new_samples as f64 / elapsed_secs
+    } else {
+        0.0
+    }
+}
+
+/// Substitutes the stale per-iteration snapshot count for `label_pos` with
+/// the freshly computed `current_in_flight` and returns the corrected global total.
+pub fn compute_global_in_flight(counts: &[u64], label_pos: usize, current_in_flight: u64) -> u64 {
+    counts.iter().sum::<u64>() - counts[label_pos] + current_in_flight
+}
+
+/// Computes how far a split is behind (or ahead of) its proportional fair
+/// share of the global total, and returns a display string.
+pub fn compute_deficit_str(
+    in_flight: u64,
+    global_in_flight: u64,
+    ratio: f32,
+    ratio_sum: f32,
+) -> String {
+    let fair_share = if ratio_sum > 0.0 {
+        (global_in_flight as f64 * ratio as f64 / ratio_sum as f64).ceil() as u64
+    } else {
+        0
+    };
+    let deficit = fair_share.saturating_sub(in_flight);
+    if deficit > 0 {
+        format!("+{} behind", deficit)
+    } else {
+        "on target".to_string()
+    }
+}
+
+/// Returns `true` when the in-flight sample count has reached the per-split cap.
+/// `max == 0` means unlimited — never at limit.
+pub fn at_sample_limit(max: u64, total_written: u64, pending_len: u64) -> bool {
+    max > 0 && total_written + pending_len >= max
+}
+
+/// Returns `true` when the current step should trigger a flush-to-disk.
+pub fn should_flush_now(
+    step_num: u64,
+    steps_per_batch: u64,
+    ctrl_c: bool,
+    hit_limit: bool,
+) -> bool {
+    step_num.is_multiple_of(steps_per_batch) || ctrl_c || hit_limit
+}
+
+// TODO: This needs to be reworked. This is a major hack.
+/// Returns `true` when a sampler error message indicates normal split
+/// exhaustion rather than a genuine error.
+pub fn is_exhaustion_error(msg: &str) -> bool {
+    msg.contains("exhausted")
+        || msg.contains("no more")
+        || msg.contains("empty")
+        || msg.contains("no eligible")
+}
+
+/// Scale a max sample count proportionally based on split ratios.
+pub fn scale_max(max_train_samples: u64, ratio: f32, train_ratio: f32) -> u64 {
+    if max_train_samples == 0 {
+        return 0;
+    }
+    ((max_train_samples as f64 * ratio as f64 / train_ratio as f64).ceil() as u64).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_split_to_fill_skips_exhausted() {
+        let labels = [SplitLabel::Train, SplitLabel::Validation];
+        let counts = [0, 0];
+        let maxes = [100, 100];
+        let ratios = [0.8, 0.2];
+        let exhausted = [true, false];
+        assert_eq!(
+            next_split_to_fill(&labels, &counts, &maxes, &ratios, &exhausted),
+            Some(SplitLabel::Validation)
+        );
+    }
+
+    #[test]
+    fn next_split_to_fill_skips_at_limit() {
+        let labels = [SplitLabel::Train, SplitLabel::Validation];
+        let counts = [100, 0];
+        let maxes = [100, 100];
+        let ratios = [0.8, 0.2];
+        let exhausted = [false, false];
+        assert_eq!(
+            next_split_to_fill(&labels, &counts, &maxes, &ratios, &exhausted),
+            Some(SplitLabel::Validation)
+        );
+    }
+
+    #[test]
+    fn next_split_to_fill_returns_none_when_all_done() {
+        let labels = [SplitLabel::Train, SplitLabel::Validation];
+        let counts = [100, 100];
+        let maxes = [100, 100];
+        let ratios = [0.8, 0.2];
+        let exhausted = [false, false];
+        assert_eq!(
+            next_split_to_fill(&labels, &counts, &maxes, &ratios, &exhausted),
+            None
+        );
+    }
+
+    #[test]
+    fn next_split_to_fill_picks_most_behind() {
+        let labels = [SplitLabel::Train, SplitLabel::Validation];
+        let counts = [50, 10];
+        let maxes = [100, 100];
+        let ratios = [0.8, 0.2];
+        let exhausted = [false, false];
+        assert_eq!(
+            next_split_to_fill(&labels, &counts, &maxes, &ratios, &exhausted),
+            Some(SplitLabel::Validation)
+        );
+    }
+
+    #[test]
+    fn scheduler_locks_and_unlocks() {
+        let labels = [SplitLabel::Train, SplitLabel::Validation];
+        let counts = [0, 0];
+        let maxes = [100, 100];
+        let ratios = [0.8, 0.2];
+        let exhausted = [false, false];
+
+        let mut sched = SplitScheduler::new();
+        let (label, newly) = sched
+            .next(&labels, &counts, &maxes, &ratios, &exhausted)
+            .unwrap();
+        assert!(newly);
+        assert_eq!(label, SplitLabel::Train);
+
+        let (label, newly) = sched
+            .next(&labels, &counts, &maxes, &ratios, &exhausted)
+            .unwrap();
+        assert!(!newly);
+        assert_eq!(label, SplitLabel::Train);
+
+        sched.unlock();
+        let (label, _) = sched
+            .next(&labels, &counts, &maxes, &ratios, &exhausted)
+            .unwrap();
+        assert_eq!(label, SplitLabel::Train);
+    }
+
+    #[test]
+    fn steps_until_next_flush_basic() {
+        assert_eq!(steps_until_next_flush(0, 100), 100);
+        assert_eq!(steps_until_next_flush(1, 100), 99);
+        assert_eq!(steps_until_next_flush(99, 100), 1);
+    }
+
+    #[test]
+    fn should_flush_now_at_boundary() {
+        assert!(should_flush_now(100, 100, false, false));
+        assert!(!should_flush_now(50, 100, false, false));
+        assert!(should_flush_now(50, 100, true, false));
+        assert!(should_flush_now(50, 100, false, true));
+    }
+
+    #[test]
+    fn at_sample_limit_zero_means_unlimited() {
+        assert!(!at_sample_limit(0, 0, 100));
+    }
+
+    #[test]
+    fn at_sample_limit_at_cap() {
+        assert!(at_sample_limit(100, 90, 10));
+    }
+
+    #[test]
+    fn is_exhaustion_error_detects_messages() {
+        assert!(is_exhaustion_error("sampler exhausted"));
+        assert!(is_exhaustion_error("no more data"));
+        assert!(is_exhaustion_error("source empty"));
+        assert!(is_exhaustion_error("no eligible records"));
+        assert!(!is_exhaustion_error("connection refused"));
+    }
+
+    #[test]
+    fn compute_samples_per_sec_basic() {
+        assert_eq!(compute_samples_per_sec(100, 10.0), 10.0);
+        assert_eq!(compute_samples_per_sec(100, 0.0), 0.0);
+    }
+
+    #[test]
+    fn compute_deficit_str_behind() {
+        let s = compute_deficit_str(10, 100, 0.8, 1.0);
+        assert!(s.contains("behind"));
+    }
+
+    #[test]
+    fn compute_deficit_str_on_target() {
+        let s = compute_deficit_str(75, 100, 0.75, 1.0);
+        assert_eq!(s, "on target", "got: {s}");
+    }
+
+    #[test]
+    fn compute_global_in_flight_substitutes_stale_count() {
+        let counts = vec![800u64, 100u64];
+        assert_eq!(compute_global_in_flight(&counts, 0, 864), 964);
+    }
+
+    #[test]
+    fn compute_global_in_flight_val_position() {
+        let counts = vec![800u64, 100u64];
+        assert_eq!(compute_global_in_flight(&counts, 1, 164), 964);
+    }
+
+    #[test]
+    fn compute_global_in_flight_single_split() {
+        let counts = vec![500u64];
+        assert_eq!(compute_global_in_flight(&counts, 0, 564), 564);
+    }
+
+    #[test]
+    fn scale_max_unlimited_when_zero() {
+        assert_eq!(scale_max(0, 0.8, 0.8), 0);
+    }
+
+    #[test]
+    fn scale_max_proportional() {
+        assert_eq!(scale_max(1000, 0.2, 0.8), 250);
+    }
+
+    #[test]
+    fn scale_max_rounds_up() {
+        assert_eq!(scale_max(100, 0.1, 0.8), 13);
+    }
+
+    #[test]
+    fn scale_max_clamps_to_one() {
+        assert_eq!(scale_max(1, 0.1, 0.8), 1);
+    }
+}

--- a/crates/triplets-offline-embedder/src/split_state.rs
+++ b/crates/triplets-offline-embedder/src/split_state.rs
@@ -1,0 +1,1631 @@
+use std::time::Instant;
+
+use triplets_core::SplitLabel;
+
+use crate::traits::{
+    BatchProvider, EmbedStore, Embedder, PairWriteArgs, Result, SamplerBatch, SchedulerConfig,
+    SchedulerError, StepResult, TripletWriteArgs,
+};
+
+/// Output mode for the embedding store.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EmbedMode {
+    /// Pair mode: anchor + positive per entry.
+    Pair,
+    /// Triplet mode: anchor + positive + negative per entry.
+    Triplet,
+}
+
+/// Per-split runtime state used by the main precompute loop.
+///
+/// Generic over `S: EmbedStore` so the storage backend is injected by the
+/// caller rather than hardcoded.
+pub struct SplitState<S: EmbedStore> {
+    /// Split label for this state.
+    pub label: SplitLabel,
+    /// Human-readable name (e.g. "train", "val").
+    pub name: &'static str,
+    /// The embedding store for this split.
+    pub store: S,
+    /// Output mode for this store.
+    pub mode: EmbedMode,
+    /// Expected embedding dimension (for validation).
+    pub emb_dim: usize,
+    /// Target max samples (0 = no limit).
+    pub max: u64,
+    /// Ratio weight used by `next_split_to_fill`.
+    pub ratio: f32,
+    /// Running count of durably-written samples (updated after each flush).
+    pub total_written: u64,
+    /// Per-split step counter (# of embed HTTP calls for this split).
+    pub step_num: u64,
+    /// Per-split flush counter.
+    pub batch_num: u64,
+    // TODO: Refactor these pending things; what is preventing massive syncronization issues?
+    /// Accumulation buffers between flush points (pair mode).
+    pub pending_anchor_vecs: Vec<Vec<f32>>,
+    /// Pending anchor texts.
+    pub pending_anchor_texts: Vec<String>,
+    /// Pending positive embedding vectors.
+    pub pending_pos_vecs: Vec<Vec<f32>>,
+    /// Pending positive texts.
+    pub pending_pos_texts: Vec<String>,
+    /// Additional buffers for triplet mode.
+    pub pending_neg_vecs: Vec<Vec<f32>>,
+    /// Pending negative texts.
+    pub pending_neg_texts: Vec<String>,
+    /// Sampler has no more data for this split.
+    pub exhausted: bool,
+    /// Number of batches dropped due to embed/validation failures.
+    pub dropped_batches: u64,
+    /// Total batches processed (including dropped ones) for circuit breaker.
+    pub total_batches: u64,
+    /// Number of input texts dropped due to embed/validation failures.
+    pub dropped_samples: u64,
+    /// Wall-clock start for throughput / ETA.
+    pub start: Option<Instant>,
+    /// Sample count at the start of the current segment (reset each time
+    /// this split is newly selected).
+    pub segment_base: u64,
+}
+
+impl<S: EmbedStore> SplitState<S> {
+    /// Whether the pending buffers are empty.
+    pub fn is_pending_empty(&self) -> bool {
+        self.pending_anchor_vecs.is_empty()
+    }
+
+    /// Number of pending samples.
+    pub fn pending_len(&self) -> u64 {
+        self.pending_anchor_vecs.len() as u64
+    }
+
+    /// Total in-flight samples (written + pending).
+    pub fn in_flight(&self) -> u64 {
+        self.total_written + self.pending_len()
+    }
+
+    /// Reset the stint timer and segment base.
+    pub fn on_stint_start(&mut self) {
+        self.start = Some(Instant::now());
+        self.segment_base = self.total_written;
+    }
+
+    /// Accumulate a batch of embeddings and texts into the pending buffers.
+    pub fn accumulate(
+        &mut self,
+        anchor_vecs: Vec<Vec<f32>>,
+        anchor_texts: &[String],
+        pos_vecs: Vec<Vec<f32>>,
+        pos_texts: &[String],
+        neg_vecs: Option<Vec<Vec<f32>>>,
+        neg_texts: Option<&[String]>,
+    ) {
+        self.pending_anchor_texts
+            .extend(anchor_texts.iter().cloned());
+        self.pending_anchor_vecs.extend(anchor_vecs);
+        self.pending_pos_texts.extend(pos_texts.iter().cloned());
+        self.pending_pos_vecs.extend(pos_vecs);
+        if let (Some(neg_v), Some(neg_t)) = (neg_vecs, neg_texts) {
+            self.pending_neg_texts.extend(neg_t.iter().cloned());
+            self.pending_neg_vecs.extend(neg_v);
+        }
+    }
+
+    /// Clear all pending buffers.
+    pub fn clear_pending(&mut self) {
+        self.pending_anchor_vecs.clear();
+        self.pending_anchor_texts.clear();
+        self.pending_pos_vecs.clear();
+        self.pending_pos_texts.clear();
+        self.pending_neg_vecs.clear();
+        self.pending_neg_texts.clear();
+    }
+
+    /// Process one embed step: embed the batch, validate, accumulate.
+    ///
+    /// If `config.embed_batch_size < batch.anchor_texts.len()`, the batch is
+    /// chunked and each chunk is embedded separately.
+    ///
+    /// Returns `StepResult` indicating how many samples were processed/dropped
+    /// and whether a flush is needed.
+    pub fn step(
+        &mut self,
+        batch: SamplerBatch,
+        embedder: &dyn Embedder,
+        config: &SchedulerConfig,
+    ) -> Result<StepResult> {
+        let anchor_count = batch.anchor_texts.len();
+        if anchor_count == 0 {
+            self.step_num += 1;
+            return Ok(StepResult {
+                samples_processed: 0,
+                samples_dropped: 0,
+                should_flush: false,
+            });
+        }
+
+        // Latch start time on first real embed
+        self.start.get_or_insert_with(std::time::Instant::now);
+
+        // Chunk the batch if embed_batch_size < batch size
+        let chunk_size = config.embed_batch_size.max(1);
+        let mut total_processed = 0u64;
+        let mut total_dropped = 0u64;
+
+        for chunk_start in (0..anchor_count).step_by(chunk_size) {
+            let chunk_end = (chunk_start + chunk_size).min(anchor_count);
+            let chunk_anchor = &batch.anchor_texts[chunk_start..chunk_end];
+            let chunk_pos = &batch.pos_texts[chunk_start..chunk_end];
+            let chunk_neg = batch.neg_texts.as_ref().map(|n| &n[chunk_start..chunk_end]);
+
+            // Embed anchor texts
+            let anchor_refs: Vec<&str> = chunk_anchor.iter().map(String::as_str).collect();
+            let anchor_vecs = match embedder.embed(&anchor_refs) {
+                Ok(v) => {
+                    match validate_embed_response(&v, chunk_anchor.len(), self.emb_dim) {
+                        Ok(()) => v, // zero-copy: validate in-place, keep ownership
+                        Err(_e) => {
+                            self.step_num += 1;
+                            self.dropped_batches += 1;
+                            self.total_batches += 1;
+                            self.dropped_samples += chunk_anchor.len() as u64;
+                            total_dropped += chunk_anchor.len() as u64;
+                            continue;
+                        }
+                    }
+                }
+                Err(_e) => {
+                    self.step_num += 1;
+                    self.dropped_batches += 1;
+                    self.total_batches += 1;
+                    self.dropped_samples += chunk_anchor.len() as u64;
+                    total_dropped += chunk_anchor.len() as u64;
+                    continue;
+                }
+            };
+
+            // Embed positive texts (only if different from anchor)
+            let pos_vecs = if chunk_pos == chunk_anchor {
+                anchor_vecs.clone()
+            } else {
+                let pos_refs: Vec<&str> = chunk_pos.iter().map(String::as_str).collect();
+                match embedder.embed(&pos_refs) {
+                    Ok(v) => {
+                        match validate_embed_response(&v, chunk_pos.len(), self.emb_dim) {
+                            Ok(()) => v, // zero-copy
+                            Err(_e) => {
+                                self.step_num += 1;
+                                self.dropped_batches += 1;
+                                self.total_batches += 1;
+                                self.dropped_samples += chunk_pos.len() as u64;
+                                total_dropped += chunk_pos.len() as u64;
+                                continue;
+                            }
+                        }
+                    }
+                    Err(_e) => {
+                        self.step_num += 1;
+                        self.dropped_batches += 1;
+                        self.total_batches += 1;
+                        self.dropped_samples += chunk_pos.len() as u64;
+                        total_dropped += chunk_pos.len() as u64;
+                        continue;
+                    }
+                }
+            };
+
+            // Embed negative texts (triplet mode only)
+            let neg_vecs = if let Some(neg_texts) = chunk_neg {
+                if neg_texts == chunk_anchor {
+                    Some(anchor_vecs.clone())
+                } else if neg_texts == chunk_pos {
+                    Some(pos_vecs.clone())
+                } else {
+                    let neg_refs: Vec<&str> = neg_texts.iter().map(String::as_str).collect();
+                    match embedder.embed(&neg_refs) {
+                        Ok(v) => {
+                            match validate_embed_response(&v, neg_texts.len(), self.emb_dim) {
+                                Ok(()) => Some(v), // zero-copy
+                                Err(_e) => {
+                                    self.step_num += 1;
+                                    self.dropped_batches += 1;
+                                    self.total_batches += 1;
+                                    self.dropped_samples += neg_texts.len() as u64;
+                                    total_dropped += neg_texts.len() as u64;
+                                    continue;
+                                }
+                            }
+                        }
+                        Err(_e) => {
+                            self.step_num += 1;
+                            self.dropped_batches += 1;
+                            self.total_batches += 1;
+                            self.dropped_samples += neg_texts.len() as u64;
+                            total_dropped += neg_texts.len() as u64;
+                            continue;
+                        }
+                    }
+                }
+            } else {
+                None
+            };
+
+            self.step_num += 1;
+            self.total_batches += 1;
+            total_processed += chunk_anchor.len() as u64;
+
+            // Accumulate into pending buffers
+            self.accumulate(
+                anchor_vecs,
+                chunk_anchor,
+                pos_vecs,
+                chunk_pos,
+                neg_vecs,
+                chunk_neg,
+            );
+        }
+
+        // Circuit breaker: halt if sustained failure rate exceeds 5%
+        if self.total_batches >= 10 {
+            let drop_rate = self.dropped_batches as f64 / self.total_batches as f64;
+            if drop_rate > 0.05 {
+                return Err(SchedulerError::Msg(format!(
+                    "circuit breaker: {:.1}% batch drop rate exceeds 5% threshold ({} dropped / {} total)",
+                    drop_rate * 100.0,
+                    self.dropped_batches,
+                    self.total_batches
+                )));
+            }
+        }
+
+        let should_flush = self.step_num.is_multiple_of(config.steps_per_batch);
+        Ok(StepResult {
+            samples_processed: total_processed,
+            samples_dropped: total_dropped,
+            should_flush,
+        })
+    }
+}
+
+/// Validate an embedding response in-place: check count, dimension, and
+/// non-finite values.  Returns `Ok(())` on success — the caller retains
+/// ownership of the vectors without any clone.
+pub fn validate_embed_response(
+    vecs: &[Vec<f32>],
+    expected_count: usize,
+    expected_dim: usize,
+) -> Result<()> {
+    if vecs.len() != expected_count {
+        return Err(SchedulerError::Msg(format!(
+            "embedding count mismatch: got {}, expected {}",
+            vecs.len(),
+            expected_count
+        )));
+    }
+    for (i, vec) in vecs.iter().enumerate() {
+        if vec.len() != expected_dim {
+            return Err(SchedulerError::Msg(format!(
+                "embedding dimension mismatch at index {}: got {}, expected {}",
+                i,
+                vec.len(),
+                expected_dim
+            )));
+        }
+        if let Some(j) = vec.iter().position(|x| !x.is_finite()) {
+            return Err(SchedulerError::Msg(format!(
+                "non-finite embedding value at index {} component {}",
+                i, j
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Flush accumulated samples into the store and persist sampler state.
+///
+/// No-op if the buffers are empty.
+pub fn flush_pending<S: EmbedStore, P: BatchProvider>(
+    state: &mut SplitState<S>,
+    provider: &P,
+) -> Result<()> {
+    let pending_count = state.pending_anchor_vecs.len();
+    if pending_count == 0 {
+        return Ok(());
+    }
+
+    let anchor_texts: Vec<&str> = state
+        .pending_anchor_texts
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let pos_texts: Vec<&str> = state.pending_pos_texts.iter().map(String::as_str).collect();
+
+    match state.mode {
+        EmbedMode::Pair => {
+            state.store.write_pairs(
+                state.total_written,
+                &PairWriteArgs {
+                    anchor_vecs: &state.pending_anchor_vecs,
+                    anchor_texts: &anchor_texts,
+                    pos_vecs: &state.pending_pos_vecs,
+                    pos_texts: &pos_texts,
+                },
+            )?;
+        }
+        EmbedMode::Triplet => {
+            let neg_texts: Vec<&str> = state.pending_neg_texts.iter().map(String::as_str).collect();
+            state.store.write_triplets(
+                state.total_written,
+                &TripletWriteArgs {
+                    anchor_vecs: &state.pending_anchor_vecs,
+                    anchor_texts: &anchor_texts,
+                    pos_vecs: &state.pending_pos_vecs,
+                    pos_texts: &pos_texts,
+                    neg_vecs: &state.pending_neg_vecs,
+                    neg_texts: &neg_texts,
+                },
+            )?;
+        }
+    }
+
+    state.total_written += pending_count as u64;
+    state.clear_pending();
+    provider.save_state()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    type PairWrite = (u64, Vec<Vec<f32>>, Vec<Vec<f32>>);
+    type TripletWrite = (u64, Vec<Vec<f32>>, Vec<Vec<f32>>, Vec<Vec<f32>>);
+
+    struct MockStore {
+        pair_writes: Mutex<Vec<PairWrite>>,
+        triplet_writes: Mutex<Vec<TripletWrite>>,
+        len: AtomicUsize,
+    }
+
+    impl MockStore {
+        fn new() -> Self {
+            Self {
+                pair_writes: Mutex::new(Vec::new()),
+                triplet_writes: Mutex::new(Vec::new()),
+                len: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl EmbedStore for MockStore {
+        fn write_pairs(&self, start_idx: u64, args: &PairWriteArgs<'_>) -> Result<()> {
+            self.pair_writes.lock().unwrap().push((
+                start_idx,
+                args.anchor_vecs.to_vec(),
+                args.pos_vecs.to_vec(),
+            ));
+            self.len
+                .fetch_add(args.anchor_vecs.len(), Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn write_triplets(&self, start_idx: u64, args: &TripletWriteArgs<'_>) -> Result<()> {
+            self.triplet_writes.lock().unwrap().push((
+                start_idx,
+                args.anchor_vecs.to_vec(),
+                args.pos_vecs.to_vec(),
+                args.neg_vecs.to_vec(),
+            ));
+            self.len
+                .fetch_add(args.anchor_vecs.len(), Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn len(&self) -> Result<u64> {
+            Ok(self.len.load(Ordering::Relaxed) as u64)
+        }
+    }
+
+    struct MockProvider;
+
+    impl BatchProvider for MockProvider {
+        fn next_batch(&self, _split: SplitLabel) -> Result<Option<crate::traits::SamplerBatch>> {
+            Ok(None)
+        }
+        fn save_state(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    struct MockEmbedder {
+        dim: usize,
+    }
+
+    impl MockEmbedder {
+        fn new(dim: usize) -> Self {
+            Self { dim }
+        }
+    }
+
+    impl Embedder for MockEmbedder {
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            Ok(texts
+                .iter()
+                .enumerate()
+                .map(|(i, _)| vec![i as f32; self.dim])
+                .collect())
+        }
+    }
+
+    struct FailingEmbedder;
+
+    impl Embedder for FailingEmbedder {
+        fn embed(&self, _texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            Err(SchedulerError::Msg("embed failed".into()))
+        }
+    }
+
+    fn make_state(store: MockStore, mode: EmbedMode, emb_dim: usize) -> SplitState<MockStore> {
+        SplitState {
+            label: SplitLabel::Train,
+            name: "train",
+            store,
+            mode,
+            emb_dim,
+            max: 100,
+            ratio: 0.8,
+            total_written: 0,
+            step_num: 0,
+            batch_num: 0,
+            pending_anchor_vecs: Vec::new(),
+            pending_anchor_texts: Vec::new(),
+            pending_pos_vecs: Vec::new(),
+            pending_pos_texts: Vec::new(),
+            pending_neg_vecs: Vec::new(),
+            pending_neg_texts: Vec::new(),
+            exhausted: false,
+            dropped_batches: 0,
+            total_batches: 0,
+            dropped_samples: 0,
+            start: None,
+            segment_base: 0,
+        }
+    }
+
+    #[test]
+    fn accumulate_and_flush_pair() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+
+        state.accumulate(
+            vec![vec![1.0, 2.0], vec![3.0, 4.0]],
+            &["a1".into(), "a2".into()],
+            vec![vec![5.0, 6.0], vec![7.0, 8.0]],
+            &["p1".into(), "p2".into()],
+            None,
+            None,
+        );
+
+        assert_eq!(state.pending_len(), 2);
+        assert_eq!(state.in_flight(), 2);
+
+        let provider = MockProvider;
+        flush_pending(&mut state, &provider).unwrap();
+
+        assert_eq!(state.total_written, 2);
+        assert!(state.is_pending_empty());
+
+        let writes = state.store.pair_writes.lock().unwrap();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].0, 0); // start_idx
+    }
+
+    #[test]
+    fn flush_pending_empty_is_noop() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        state.total_written = 5;
+
+        let provider = MockProvider;
+        flush_pending(&mut state, &provider).unwrap();
+        assert_eq!(state.total_written, 5);
+    }
+
+    #[test]
+    fn on_stint_start_resets_segment() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        state.total_written = 50;
+
+        state.on_stint_start();
+        assert!(state.start.is_some());
+        assert_eq!(state.segment_base, 50);
+    }
+
+    #[test]
+    fn step_pair_mode_accumulates() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        let embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(2, 2, 2, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a1".into(), "a2".into()],
+            pos_texts: vec!["p1".into(), "p2".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 2);
+        assert_eq!(result.samples_dropped, 0);
+        assert!(!result.should_flush);
+
+        assert_eq!(state.pending_len(), 2);
+        assert_eq!(state.step_num, 1);
+    }
+
+    #[test]
+    fn step_triplet_mode_accumulates() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Triplet, 2);
+        let embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(1, 1, 2, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a1".into()],
+            pos_texts: vec!["p1".into()],
+            neg_texts: Some(vec!["n1".into()]),
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 1);
+        assert_eq!(result.samples_dropped, 0);
+
+        assert_eq!(state.pending_len(), 1);
+        assert_eq!(state.pending_neg_vecs.len(), 1);
+    }
+
+    #[test]
+    fn step_flush_at_boundary() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        state.step_num = 99; // next step will be 100
+        let embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(1, 1, 2, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a1".into()],
+            pos_texts: vec!["p1".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert!(result.should_flush);
+    }
+
+    #[test]
+    fn step_embed_failure_drops_batch() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        let embedder = FailingEmbedder;
+        let config = SchedulerConfig::new(2, 2, 2, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a1".into(), "a2".into()],
+            pos_texts: vec!["p1".into(), "p2".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 0);
+        assert_eq!(result.samples_dropped, 2);
+        assert_eq!(state.dropped_batches, 1);
+        assert_eq!(state.dropped_samples, 2);
+        assert!(state.is_pending_empty());
+    }
+
+    #[test]
+    fn step_chunking_when_embed_batch_smaller() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        let embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(4, 2, 2, 100); // sampler=4, embed=2
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a1".into(), "a2".into(), "a3".into(), "a4".into()],
+            pos_texts: vec!["p1".into(), "p2".into(), "p3".into(), "p4".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 4);
+        assert_eq!(result.samples_dropped, 0);
+        assert_eq!(state.pending_len(), 4);
+        // 4 texts / 2 chunk_size = 2 embed calls = 2 step increments
+        assert_eq!(state.step_num, 2);
+    }
+
+    #[test]
+    fn validate_embed_response_ok() {
+        let vecs = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+        validate_embed_response(&vecs, 2, 2).unwrap();
+    }
+
+    #[test]
+    fn validate_embed_response_count_mismatch() {
+        let vecs = vec![vec![1.0, 2.0]];
+        let err = validate_embed_response(&vecs, 2, 2).unwrap_err();
+        assert!(err.to_string().contains("count mismatch"));
+    }
+
+    #[test]
+    fn validate_embed_response_dim_mismatch() {
+        let vecs = vec![vec![1.0], vec![3.0, 4.0]];
+        let err = validate_embed_response(&vecs, 2, 2).unwrap_err();
+        assert!(err.to_string().contains("dimension mismatch"));
+    }
+
+    #[test]
+    fn validate_embed_response_non_finite() {
+        let vecs = vec![vec![1.0, f32::NAN], vec![3.0, 4.0]];
+        let err = validate_embed_response(&vecs, 2, 2).unwrap_err();
+        assert!(err.to_string().contains("non-finite"));
+    }
+
+    // ------------------------------------------------------------------
+    // Coverage gap tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn step_empty_batch_returns_zero() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        let embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(1, 1, 2, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec![],
+            pos_texts: vec![],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 0);
+        assert_eq!(result.samples_dropped, 0);
+        assert!(!result.should_flush);
+        assert!(state.is_pending_empty());
+        assert_eq!(state.step_num, 1); // incremented even for empty
+    }
+
+    #[test]
+    fn step_pos_equals_anchor_reuses_vectors() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        // Embedder that tracks call count
+        let embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(1, 1, 2, 100);
+
+        // anchor_texts == pos_texts → only 1 embed call (anchor), pos reuses
+        let batch = SamplerBatch {
+            anchor_texts: vec!["same".into()],
+            pos_texts: vec!["same".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 1);
+        assert_eq!(state.pending_len(), 1);
+        // MockEmbedder called once for anchor; pos reuses anchor_vecs
+        // So pending_pos_vecs should equal pending_anchor_vecs
+        assert_eq!(state.pending_anchor_vecs, state.pending_pos_vecs);
+    }
+
+    #[test]
+    fn step_neg_equals_anchor_reuses_vectors() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Triplet, 2);
+        let embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(1, 1, 2, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a".into()],
+            pos_texts: vec!["p".into()],
+            neg_texts: Some(vec!["a".into()]), // neg == anchor
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 1);
+        assert_eq!(state.pending_neg_vecs.len(), 1);
+        // neg should reuse anchor vectors
+        assert_eq!(state.pending_neg_vecs, state.pending_anchor_vecs);
+    }
+
+    #[test]
+    fn step_neg_equals_pos_reuses_vectors() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Triplet, 2);
+        let embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(1, 1, 2, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a".into()],
+            pos_texts: vec!["p".into()],
+            neg_texts: Some(vec!["p".into()]), // neg == pos
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 1);
+        // neg should reuse pos vectors
+        assert_eq!(state.pending_neg_vecs, state.pending_pos_vecs);
+    }
+
+    #[test]
+    fn step_neg_embed_failure_drops_batch() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Triplet, 2);
+        let _embedder = MockEmbedder::new(2);
+        let config = SchedulerConfig::new(1, 1, 2, 100);
+
+        // Make neg different from anchor and pos so it triggers embed call
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a".into()],
+            pos_texts: vec!["p".into()],
+            neg_texts: Some(vec!["n".into()]),
+        };
+
+        // Override embedder to fail on "n" but succeed on "a" and "p"
+        struct NegFailingEmbedder;
+        impl Embedder for NegFailingEmbedder {
+            fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+                if texts.contains(&"n") {
+                    Err(SchedulerError::Msg("neg embed failed".into()))
+                } else {
+                    Ok(texts.iter().map(|_| vec![1.0; 2]).collect())
+                }
+            }
+        }
+
+        let result = state.step(batch, &NegFailingEmbedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 0);
+        assert_eq!(result.samples_dropped, 1);
+        assert_eq!(state.dropped_batches, 1);
+        assert_eq!(state.dropped_samples, 1);
+    }
+
+    #[test]
+    fn accumulate_with_negatives() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Triplet, 2);
+
+        state.accumulate(
+            vec![vec![1.0, 2.0]],
+            &["a".into()],
+            vec![vec![3.0, 4.0]],
+            &["p".into()],
+            Some(vec![vec![5.0, 6.0]]),
+            Some(&["n".into()]),
+        );
+
+        assert_eq!(state.pending_len(), 1);
+        assert_eq!(state.pending_neg_vecs.len(), 1);
+        assert_eq!(state.pending_neg_texts, vec!["n"]);
+    }
+
+    #[test]
+    fn flush_pending_triplet_mode() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Triplet, 2);
+        state.accumulate(
+            vec![vec![1.0, 2.0], vec![3.0, 4.0]],
+            &["a1".into(), "a2".into()],
+            vec![vec![5.0, 6.0], vec![7.0, 8.0]],
+            &["p1".into(), "p2".into()],
+            Some(vec![vec![9.0, 10.0], vec![11.0, 12.0]]),
+            Some(&["n1".into(), "n2".into()]),
+        );
+
+        let provider = MockProvider;
+        flush_pending(&mut state, &provider).unwrap();
+
+        assert_eq!(state.total_written, 2);
+        assert!(state.is_pending_empty());
+
+        let writes = state.store.triplet_writes.lock().unwrap();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].0, 0); // start_idx
+        assert_eq!(writes[0].1.len(), 2); // anchor vecs
+        assert_eq!(writes[0].2.len(), 2); // pos vecs
+        assert_eq!(writes[0].3.len(), 2); // neg vecs
+    }
+
+    struct FailingProvider;
+
+    impl BatchProvider for FailingProvider {
+        fn next_batch(&self, _split: SplitLabel) -> Result<Option<crate::traits::SamplerBatch>> {
+            Ok(None)
+        }
+        fn save_state(&self) -> Result<()> {
+            Err(SchedulerError::Msg("save failed".into()))
+        }
+    }
+
+    #[test]
+    fn flush_pending_save_state_error_propagates() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 2);
+        state.accumulate(
+            vec![vec![1.0, 2.0]],
+            &["a".into()],
+            vec![vec![3.0, 4.0]],
+            &["p".into()],
+            None,
+            None,
+        );
+
+        let provider = FailingProvider;
+        let err = flush_pending(&mut state, &provider).unwrap_err();
+        assert!(err.to_string().contains("save failed"));
+        // Data was written to store (write_pairs succeeded), but state wasn't saved
+        // In a real system this would need transactional semantics
+    }
+
+    #[test]
+    fn validate_embed_response_infinity() {
+        let vecs = vec![vec![1.0, f32::INFINITY], vec![3.0, 4.0]];
+        let err = validate_embed_response(&vecs, 2, 2).unwrap_err();
+        assert!(err.to_string().contains("non-finite"));
+    }
+
+    #[test]
+    fn validate_embed_response_neg_infinity() {
+        let vecs = vec![vec![1.0, 2.0], vec![f32::NEG_INFINITY, 4.0]];
+        let err = validate_embed_response(&vecs, 2, 2).unwrap_err();
+        assert!(err.to_string().contains("non-finite"));
+    }
+
+    // ===================================================================
+    // ALIGNMENT TESTS — highest priority for data integrity
+    //
+    // When embed_batch_size < sampler_batch_size, texts are chunked and
+    // embedded in separate calls.  A misalignment bug would silently
+    // corrupt training data.  These tests verify that every text-vector
+    // pair remains correctly matched across all chunks.
+    // ===================================================================
+
+    /// Deterministic embedder that returns a unique vector per text.
+    /// Uses text content as the first component so alignment can be verified.
+    /// The second component encodes the chunk-local position (0-based within
+    /// each embed call) so we can detect off-by-one at chunk boundaries.
+    struct AlignmentEmbedder {
+        dim: usize,
+    }
+
+    impl AlignmentEmbedder {
+        fn new(dim: usize) -> Self {
+            Self { dim }
+        }
+    }
+
+    impl Embedder for AlignmentEmbedder {
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            Ok(texts
+                .iter()
+                .enumerate()
+                .map(|(i, t)| {
+                    // Encode text identity as a float in the first slot
+                    let text_id = t.chars().map(|c| c as u32 as f32).sum::<f32>();
+                    let mut v = vec![0.0; self.dim];
+                    v[0] = text_id;
+                    if self.dim > 1 {
+                        v[1] = i as f32; // chunk-local position
+                    }
+                    v
+                })
+                .collect())
+        }
+    }
+
+    #[test]
+    fn alignment_sampler_larger_than_embed_batch_pair() {
+        // sampler_batch=6, embed_batch=2 → 3 chunks
+        // Verify all 6 entries are correctly aligned after chunking
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(6, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec![
+                "a1".into(),
+                "a2".into(),
+                "a3".into(),
+                "a4".into(),
+                "a5".into(),
+                "a6".into(),
+            ],
+            pos_texts: vec![
+                "p1".into(),
+                "p2".into(),
+                "p3".into(),
+                "p4".into(),
+                "p5".into(),
+                "p6".into(),
+            ],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 6);
+        assert_eq!(state.pending_len(), 6);
+        // 6 texts / 2 chunk_size = 3 embed calls = 3 step increments
+        assert_eq!(state.step_num, 3);
+
+        // CRITICAL: verify alignment — each pending text must match its vector
+        assert_eq!(state.pending_anchor_texts.len(), 6);
+        assert_eq!(state.pending_anchor_vecs.len(), 6);
+        assert_eq!(state.pending_pos_texts.len(), 6);
+        assert_eq!(state.pending_pos_vecs.len(), 6);
+
+        for i in 0..6 {
+            let anchor_text = format!("a{}", i + 1);
+            let pos_text = format!("p{}", i + 1);
+            let expected_anchor_id: f32 = anchor_text.chars().map(|c| c as u32 as f32).sum();
+            let expected_pos_id: f32 = pos_text.chars().map(|c| c as u32 as f32).sum();
+            // vec[1] = chunk-local position (embed_batch=2, so resets every 2)
+            let chunk_local_pos = (i % 2) as f32;
+
+            assert_eq!(
+                state.pending_anchor_texts[i], anchor_text,
+                "anchor text mismatch at index {i}"
+            );
+            assert_eq!(
+                state.pending_anchor_vecs[i][0], expected_anchor_id,
+                "anchor vector text_id mismatch at index {i}"
+            );
+            assert_eq!(
+                state.pending_anchor_vecs[i][1], chunk_local_pos,
+                "anchor vector position mismatch at index {i}"
+            );
+            assert_eq!(
+                state.pending_pos_texts[i], pos_text,
+                "pos text mismatch at index {i}"
+            );
+            assert_eq!(
+                state.pending_pos_vecs[i][0], expected_pos_id,
+                "pos vector text_id mismatch at index {i}"
+            );
+            assert_eq!(
+                state.pending_pos_vecs[i][1], chunk_local_pos,
+                "pos vector position mismatch at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn alignment_sampler_larger_than_embed_batch_triplet() {
+        // sampler_batch=5, embed_batch=2 → 3 chunks (2+2+1)
+        // Verify anchor/positive/negative stay aligned across chunks
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Triplet, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(5, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec![
+                "a1".into(),
+                "a2".into(),
+                "a3".into(),
+                "a4".into(),
+                "a5".into(),
+            ],
+            pos_texts: vec![
+                "p1".into(),
+                "p2".into(),
+                "p3".into(),
+                "p4".into(),
+                "p5".into(),
+            ],
+            neg_texts: Some(vec![
+                "n1".into(),
+                "n2".into(),
+                "n3".into(),
+                "n4".into(),
+                "n5".into(),
+            ]),
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 5);
+        assert_eq!(state.pending_len(), 5);
+
+        // Verify all 5 entries aligned across all 3 text/vector buffers
+        for i in 0..5 {
+            let anchor_text = format!("a{}", i + 1);
+            let pos_text = format!("p{}", i + 1);
+            let neg_text = format!("n{}", i + 1);
+            let expected_anchor_id: f32 = anchor_text.chars().map(|c| c as u32 as f32).sum();
+            let expected_pos_id: f32 = pos_text.chars().map(|c| c as u32 as f32).sum();
+            let expected_neg_id: f32 = neg_text.chars().map(|c| c as u32 as f32).sum();
+            let chunk_local_pos = (i % 2) as f32;
+
+            assert_eq!(
+                state.pending_anchor_texts[i], anchor_text,
+                "anchor text mismatch at {i}"
+            );
+            assert_eq!(
+                state.pending_anchor_vecs[i][0], expected_anchor_id,
+                "anchor vec text_id mismatch at {i}"
+            );
+            assert_eq!(
+                state.pending_anchor_vecs[i][1], chunk_local_pos,
+                "anchor vec position mismatch at {i}"
+            );
+            assert_eq!(
+                state.pending_pos_texts[i], pos_text,
+                "pos text mismatch at {i}"
+            );
+            assert_eq!(
+                state.pending_pos_vecs[i][0], expected_pos_id,
+                "pos vec text_id mismatch at {i}"
+            );
+            assert_eq!(
+                state.pending_pos_vecs[i][1], chunk_local_pos,
+                "pos vec position mismatch at {i}"
+            );
+            assert_eq!(
+                state.pending_neg_texts[i], neg_text,
+                "neg text mismatch at {i}"
+            );
+            assert_eq!(
+                state.pending_neg_vecs[i][0], expected_neg_id,
+                "neg vec text_id mismatch at {i}"
+            );
+            assert_eq!(
+                state.pending_neg_vecs[i][1], chunk_local_pos,
+                "neg vec position mismatch at {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn alignment_embed_larger_than_sampler_batch() {
+        // embed_batch=10, sampler_batch=3 → 1 chunk of 3
+        // Verify no duplication or truncation
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(3, 10, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["x1".into(), "x2".into(), "x3".into()],
+            pos_texts: vec!["y1".into(), "y2".into(), "y3".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 3);
+        assert_eq!(state.pending_len(), 3);
+
+        for i in 0..3 {
+            let text = format!("x{}", i + 1);
+            let expected_id: f32 = text.chars().map(|c| c as u32 as f32).sum();
+            assert_eq!(state.pending_anchor_texts[i], text);
+            assert_eq!(state.pending_anchor_vecs[i][0], expected_id);
+            assert_eq!(state.pending_pos_texts[i], format!("y{}", i + 1));
+        }
+    }
+
+    #[test]
+    fn alignment_exact_match_sampler_equals_embed() {
+        // embed_batch=4, sampler_batch=4 → 1 chunk, no chunking
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(4, 4, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            pos_texts: vec!["e".into(), "f".into(), "g".into(), "h".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 4);
+        assert_eq!(state.step_num, 1); // single chunk
+
+        for (i, (at, pt)) in state
+            .pending_anchor_texts
+            .iter()
+            .zip(state.pending_pos_texts.iter())
+            .enumerate()
+        {
+            let expected_id = (b'a' + i as u8) as char;
+            assert_eq!(at.as_str(), expected_id.to_string().as_str());
+            assert_eq!(pt.as_str(), ((b'e' + i as u8) as char).to_string().as_str());
+        }
+    }
+
+    #[test]
+    fn alignment_uneven_chunk_remainder() {
+        // sampler_batch=7, embed_batch=3 → 3 chunks (3+3+1)
+        // The remainder chunk (1 item) must be correctly aligned
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(7, 3, 4, 100);
+
+        let texts: Vec<String> = (0..7).map(|i| format!("t{i}")).collect();
+        let batch = SamplerBatch {
+            anchor_texts: texts.clone(),
+            pos_texts: texts.clone(), // same as anchor → tests the pos==anchor reuse path
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 7);
+        assert_eq!(state.pending_len(), 7);
+        assert_eq!(state.step_num, 3); // ceil(7/3) = 3
+
+        // All 7 entries must be correctly aligned
+        for i in 0..7 {
+            let text = format!("t{i}");
+            let expected_id: f32 = text.chars().map(|c| c as u32 as f32).sum();
+            assert_eq!(state.pending_anchor_texts[i], text, "text mismatch at {i}");
+            assert_eq!(
+                state.pending_anchor_vecs[i][0], expected_id,
+                "vector text_id mismatch at {i}"
+            );
+            // pos == anchor, so pos vectors should equal anchor vectors
+            assert_eq!(
+                state.pending_anchor_vecs[i], state.pending_pos_vecs[i],
+                "pos/anchor vec mismatch at {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn alignment_multiple_steps_compound() {
+        // Run 2 steps with different batch sizes to verify pending buffers
+        // compound correctly without interleaving
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(3, 2, 4, 100);
+
+        // Step 1: 3 texts → 2 chunks (2+1)
+        let batch1 = SamplerBatch {
+            anchor_texts: vec!["step1_a".into(), "step1_b".into(), "step1_c".into()],
+            pos_texts: vec!["step1_p1".into(), "step1_p2".into(), "step1_p3".into()],
+            neg_texts: None,
+        };
+        state.step(batch1, &embedder, &config).unwrap();
+        assert_eq!(state.pending_len(), 3);
+
+        // Step 2: 2 texts → 1 chunk
+        let batch2 = SamplerBatch {
+            anchor_texts: vec!["step2_a".into(), "step2_b".into()],
+            pos_texts: vec!["step2_p1".into(), "step2_p2".into()],
+            neg_texts: None,
+        };
+        state.step(batch2, &embedder, &config).unwrap();
+        assert_eq!(state.pending_len(), 5);
+
+        // Verify first 3 entries are from step1, last 2 from step2
+        assert_eq!(state.pending_anchor_texts[0], "step1_a");
+        assert_eq!(state.pending_anchor_texts[1], "step1_b");
+        assert_eq!(state.pending_anchor_texts[2], "step1_c");
+        assert_eq!(state.pending_anchor_texts[3], "step2_a");
+        assert_eq!(state.pending_anchor_texts[4], "step2_b");
+
+        // Verify vectors match their texts
+        for i in 0..5 {
+            let text = &state.pending_anchor_texts[i];
+            let expected_id: f32 = text.chars().map(|c| c as u32 as f32).sum();
+            assert_eq!(
+                state.pending_anchor_vecs[i][0], expected_id,
+                "vector mismatch at index {i} for text '{text}'"
+            );
+        }
+    }
+
+    #[test]
+    fn alignment_triplet_chunk_boundary_no_swap() {
+        // sampler_batch=4, embed_batch=2 → 2 chunks
+        // The boundary between chunks must not swap negative vectors
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Triplet, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(4, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec![
+                "a_odd".into(),
+                "a_even".into(),
+                "a_third".into(),
+                "a_fourth".into(),
+            ],
+            pos_texts: vec![
+                "p_odd".into(),
+                "p_even".into(),
+                "p_third".into(),
+                "p_fourth".into(),
+            ],
+            neg_texts: Some(vec![
+                "n_odd".into(),
+                "n_even".into(),
+                "n_third".into(),
+                "n_fourth".into(),
+            ]),
+        };
+
+        state.step(batch, &embedder, &config).unwrap();
+
+        // At index 0: anchor="a_odd", pos="p_odd", neg="n_odd"
+        assert_eq!(state.pending_anchor_texts[0], "a_odd");
+        assert_eq!(state.pending_pos_texts[0], "p_odd");
+        assert_eq!(state.pending_neg_texts[0], "n_odd");
+
+        // At index 2 (chunk boundary): anchor="a_third", pos="p_third", neg="n_third"
+        assert_eq!(state.pending_anchor_texts[2], "a_third");
+        assert_eq!(state.pending_pos_texts[2], "p_third");
+        assert_eq!(state.pending_neg_texts[2], "n_third");
+
+        // Verify neg vectors are NOT swapped at boundary
+        let expected_neg2_id: f32 = "n_third".chars().map(|c| c as u32 as f32).sum();
+        assert_eq!(
+            state.pending_neg_vecs[2][0], expected_neg2_id,
+            "negative vector swapped at chunk boundary!"
+        );
+    }
+
+    // ===================================================================
+    // EDGE CASE TESTS — empty texts, infinite/zero vectors, corruption
+    // ===================================================================
+
+    /// Embedder that returns all-zero vectors. Tests that alignment holds
+    /// even when vectors carry no distinguishing information.
+    struct ZeroEmbedder;
+
+    impl Embedder for ZeroEmbedder {
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![0.0; 4]).collect())
+        }
+    }
+
+    /// Embedder that returns vectors filled with infinity.
+    struct InfEmbedder;
+
+    impl Embedder for InfEmbedder {
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![f32::INFINITY; 4]).collect())
+        }
+    }
+
+    #[test]
+    fn alignment_with_zero_vectors_across_chunks() {
+        // All vectors are [0,0,0,0] — alignment must still hold text→vector pairing
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = ZeroEmbedder;
+        let config = SchedulerConfig::new(5, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec![
+                "z1".into(),
+                "z2".into(),
+                "z3".into(),
+                "z4".into(),
+                "z5".into(),
+            ],
+            pos_texts: vec![
+                "q1".into(),
+                "q2".into(),
+                "q3".into(),
+                "q4".into(),
+                "q5".into(),
+            ],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 5);
+        assert_eq!(state.pending_len(), 5);
+
+        // Texts must be aligned even if vectors are all zero
+        for i in 0..5 {
+            assert_eq!(state.pending_anchor_texts[i], format!("z{}", i + 1));
+            assert_eq!(state.pending_pos_texts[i], format!("q{}", i + 1));
+            assert_eq!(state.pending_anchor_vecs[i], vec![0.0; 4]);
+            assert_eq!(state.pending_pos_vecs[i], vec![0.0; 4]);
+        }
+    }
+
+    #[test]
+    fn alignment_with_infinite_vectors_across_chunks() {
+        // Vectors are all inf — validate_embed_response rejects non-finite,
+        // so the batch should be dropped
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = InfEmbedder;
+        let config = SchedulerConfig::new(3, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a1".into(), "a2".into(), "a3".into()],
+            pos_texts: vec!["p1".into(), "p2".into(), "p3".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 0);
+        assert_eq!(result.samples_dropped, 3);
+        assert!(state.is_pending_empty());
+    }
+
+    #[test]
+    fn alignment_with_nan_vectors_across_chunks() {
+        // Vectors contain NaN — should be rejected
+        struct NanEmbedder;
+
+        impl Embedder for NanEmbedder {
+            fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+                Ok(texts
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| {
+                        let mut v = vec![0.0; 4];
+                        if i % 2 == 0 {
+                            v[0] = f32::NAN;
+                        }
+                        v
+                    })
+                    .collect())
+            }
+        }
+
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = NanEmbedder;
+        let config = SchedulerConfig::new(4, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a1".into(), "a2".into(), "a3".into(), "a4".into()],
+            pos_texts: vec!["p1".into(), "p2".into(), "p3".into(), "p4".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        // First chunk [a1,a2] → a1 has NaN → entire chunk dropped
+        // Second chunk [a3,a4] → a3 has NaN → entire chunk dropped
+        assert_eq!(result.samples_processed, 0);
+        assert_eq!(result.samples_dropped, 4);
+        assert_eq!(state.dropped_batches, 2);
+        assert!(state.is_pending_empty());
+    }
+
+    #[test]
+    fn alignment_empty_anchor_texts_returns_zero() {
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(0, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec![],
+            pos_texts: vec![],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 0);
+        assert_eq!(result.samples_dropped, 0);
+        assert!(state.is_pending_empty());
+    }
+
+    #[test]
+    fn alignment_single_text_batch() {
+        // Edge case: sampler_batch=1, embed_batch=1 → 1 chunk of 1
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = AlignmentEmbedder::new(4);
+        let config = SchedulerConfig::new(1, 1, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["solo".into()],
+            pos_texts: vec!["partner".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 1);
+        assert_eq!(state.pending_len(), 1);
+
+        let expected_id: f32 = "solo".chars().map(|c| c as u32 as f32).sum();
+        assert_eq!(state.pending_anchor_texts[0], "solo");
+        assert_eq!(state.pending_anchor_vecs[0][0], expected_id);
+        assert_eq!(state.pending_pos_texts[0], "partner");
+    }
+
+    #[test]
+    fn alignment_all_chunks_dropped_no_residue() {
+        // If ALL chunks fail validation, pending must be completely empty
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = InfEmbedder; // returns inf → all chunks rejected
+        let config = SchedulerConfig::new(6, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec![
+                "a1".into(),
+                "a2".into(),
+                "a3".into(),
+                "a4".into(),
+                "a5".into(),
+                "a6".into(),
+            ],
+            pos_texts: vec![
+                "p1".into(),
+                "p2".into(),
+                "p3".into(),
+                "p4".into(),
+                "p5".into(),
+                "p6".into(),
+            ],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        assert_eq!(result.samples_processed, 0);
+        assert_eq!(result.samples_dropped, 6);
+        assert_eq!(state.dropped_batches, 3); // 6/2 = 3 chunks
+        assert!(state.is_pending_empty());
+        assert_eq!(state.pending_anchor_texts.len(), 0);
+        assert_eq!(state.pending_anchor_vecs.len(), 0);
+    }
+
+    #[test]
+    fn alignment_partial_drop_preserves_remaining() {
+        // Chunk 0 fails, chunk 1 succeeds → only chunk 1's data in pending
+        struct FirstChunkFailEmbedder {
+            call_count: std::sync::atomic::AtomicUsize,
+        }
+
+        impl Embedder for FirstChunkFailEmbedder {
+            fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+                let call = self.call_count.fetch_add(1, Ordering::Relaxed);
+                if call == 0 {
+                    // First embed call (chunk 0 anchor) returns wrong count
+                    Err(SchedulerError::Msg("transient failure".into()))
+                } else {
+                    Ok(texts.iter().map(|_| vec![1.0; 4]).collect())
+                }
+            }
+        }
+
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = FirstChunkFailEmbedder {
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let config = SchedulerConfig::new(4, 2, 4, 100);
+
+        let batch = SamplerBatch {
+            anchor_texts: vec!["a1".into(), "a2".into(), "a3".into(), "a4".into()],
+            pos_texts: vec!["p1".into(), "p2".into(), "p3".into(), "p4".into()],
+            neg_texts: None,
+        };
+
+        let result = state.step(batch, &embedder, &config).unwrap();
+        // Chunk 0 [a1,a2] failed → dropped
+        // Chunk 1 [a3,a4] succeeded → accumulated
+        assert_eq!(result.samples_processed, 2);
+        assert_eq!(result.samples_dropped, 2);
+        assert_eq!(state.pending_len(), 2);
+        // Only chunk 1's data should be in pending
+        assert_eq!(state.pending_anchor_texts[0], "a3");
+        assert_eq!(state.pending_anchor_texts[1], "a4");
+    }
+
+    #[test]
+    fn step_circuit_breaker_halt() {
+        struct AlwaysFailEmbedder;
+        impl Embedder for AlwaysFailEmbedder {
+            fn embed(&self, _texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+                Err(SchedulerError::Msg("systemic failure".into()))
+            }
+        }
+
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = AlwaysFailEmbedder;
+        // embed_batch_size=4 → 1 chunk per batch → 1 embed call per batch
+        let config = SchedulerConfig::new(4, 4, 4, 100);
+
+        // All batches fail. Circuit breaker fires when total_batches >= 10 AND drop_rate > 5%.
+        // With 100% failure: fires at batch index 9 (the 10th batch, total_batches=10).
+        for i in 0..12 {
+            let batch = SamplerBatch {
+                anchor_texts: vec![
+                    format!("a{i}"),
+                    format!("b{i}"),
+                    format!("c{i}"),
+                    format!("d{i}"),
+                ],
+                pos_texts: vec![
+                    format!("p{i}"),
+                    format!("q{i}"),
+                    format!("r{i}"),
+                    format!("s{i}"),
+                ],
+                neg_texts: None,
+            };
+            let result = state.step(batch, &embedder, &config);
+            if i < 9 {
+                // Batches 0-8: total_batches < 10 → no circuit breaker
+                let sr = result.unwrap();
+                assert_eq!(sr.samples_dropped, 4);
+            } else {
+                // Batch 9+: total_batches >= 10, drop_rate = 100% > 5% → Err
+                let err = result.unwrap_err();
+                assert!(
+                    err.to_string().contains("circuit breaker"),
+                    "expected circuit breaker error, got: {err}"
+                );
+            }
+        }
+        assert_eq!(state.total_batches, 12);
+        assert_eq!(state.dropped_batches, 12);
+    }
+
+    #[test]
+    fn step_circuit_breaker_no_halt_below_threshold() {
+        // Fail only on the 40th embed call (batch 20 anchor). By then total_batches=20,
+        // so 1 drop / 20 total = 5% exactly (not > 5%) → no circuit breaker.
+        struct FailOnCall40Embedder {
+            call_count: std::sync::atomic::AtomicUsize,
+        }
+        impl Embedder for FailOnCall40Embedder {
+            fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+                let call = self.call_count.fetch_add(1, Ordering::Relaxed);
+                if call == 40 {
+                    Err(SchedulerError::Msg("transient".into()))
+                } else {
+                    Ok(texts.iter().map(|_| vec![1.0; 4]).collect())
+                }
+            }
+        }
+
+        let store = MockStore::new();
+        let mut state = make_state(store, EmbedMode::Pair, 4);
+        let embedder = FailOnCall40Embedder {
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        };
+        // embed_batch_size=4 → 1 chunk per batch → 2 embed calls per batch (anchor + pos)
+        let config = SchedulerConfig::new(4, 4, 4, 100);
+
+        // 30 batches. Call 40 fails (batch 20 anchor). By then total_batches=20, rate=5% (not > 5%).
+        for i in 0..30 {
+            let batch = SamplerBatch {
+                anchor_texts: vec![
+                    format!("a{i}"),
+                    format!("b{i}"),
+                    format!("c{i}"),
+                    format!("d{i}"),
+                ],
+                pos_texts: vec![
+                    format!("p{i}"),
+                    format!("q{i}"),
+                    format!("r{i}"),
+                    format!("s{i}"),
+                ],
+                neg_texts: None,
+            };
+            let result = state.step(batch, &embedder, &config);
+            result.unwrap_or_else(|e| panic!("batch {i} should not trigger circuit breaker: {e}"));
+        }
+        assert_eq!(state.total_batches, 30);
+        assert_eq!(state.dropped_batches, 1);
+    }
+}

--- a/crates/triplets-offline-embedder/src/store_adapter.rs
+++ b/crates/triplets-offline-embedder/src/store_adapter.rs
@@ -1,0 +1,292 @@
+//! Adapter bridging [`simd_r_drive::storage_engine::DataStore`] to the
+//! [`EmbedStore`] trait, plus helpers for initializing per-split stores.
+
+use simd_r_drive::storage_engine::DataStore;
+use simd_r_drive::storage_engine::traits::DataStoreReader;
+use triplets_core::SplitLabel;
+use triplets_srd_source::srd_triplet::{self, SrdMode};
+
+use crate::split_state::{EmbedMode, SplitState};
+use crate::traits::{EmbedStore, PairWriteArgs, Result, SchedulerError, TripletWriteArgs};
+
+/// Newtype wrapping [`DataStore`] to implement [`EmbedStore`].
+///
+/// `DataStore` has its own inherent methods (`len`, etc.) whose signatures
+/// clash with the trait methods, so a newtype sidesteps the ambiguity.
+pub struct SrdStoreAdapter(pub DataStore);
+
+impl EmbedStore for SrdStoreAdapter {
+    fn write_pairs(&self, start_idx: u64, args: &PairWriteArgs<'_>) -> Result<()> {
+        srd_triplet::write_pair_entries(
+            &self.0,
+            start_idx,
+            args.anchor_vecs,
+            args.anchor_texts,
+            args.pos_vecs,
+            args.pos_texts,
+        )
+        .map_err(|e| SchedulerError::Msg(format!("write error: {e}")))
+    }
+
+    fn write_triplets(&self, start_idx: u64, args: &TripletWriteArgs<'_>) -> Result<()> {
+        srd_triplet::write_triplet_entries(
+            &self.0,
+            start_idx,
+            args.anchor_vecs,
+            args.anchor_texts,
+            args.pos_vecs,
+            args.pos_texts,
+            args.neg_vecs,
+            args.neg_texts,
+        )
+        .map_err(|e| SchedulerError::Msg(format!("write error: {e}")))
+    }
+
+    fn len(&self) -> Result<u64> {
+        self.0
+            .len()
+            .map(|n| n as u64)
+            .map_err(|e| SchedulerError::Msg(format!("len error: {e}")))
+    }
+}
+
+impl std::ops::Deref for SrdStoreAdapter {
+    type Target = DataStore;
+    fn deref(&self) -> &DataStore {
+        &self.0
+    }
+}
+
+/// Descriptor for a single split: label, display name, max samples, ratio weight.
+pub type SplitDesc = (SplitLabel, &'static str, u64, f32);
+
+/// Open (or create) per-split data stores and initialize [`SplitState`] entries.
+///
+/// Each split gets its own subdirectory under `out_dir` containing a
+/// `data.srd` store file.  If the store already exists (resume), the
+/// current sample count is read and used to compute `step_num` /
+/// `batch_num` so the scheduler picks up where it left off.
+pub fn init_split_states_with_batch(
+    out_dir: &std::path::Path,
+    split_descs: &[SplitDesc],
+    embed_batch_size: usize,
+    mode: SrdMode,
+    emb_dim: usize,
+    steps_per_batch: u64,
+) -> Result<Vec<SplitState<SrdStoreAdapter>>> {
+    let embed_mode = match mode {
+        SrdMode::Pair => EmbedMode::Pair,
+        SrdMode::Triplet => EmbedMode::Triplet,
+    };
+    let mut v = Vec::with_capacity(split_descs.len());
+    for &(label, name, max, ratio) in split_descs {
+        let split_dir = out_dir.join(name);
+        std::fs::create_dir_all(&split_dir)
+            .map_err(|e| SchedulerError::Msg(format!("create dir: {e}")))?;
+        let store = DataStore::open(&split_dir.join("data.srd"))
+            .map_err(|e| SchedulerError::Msg(format!("open store: {e}")))?;
+        let already_done = store
+            .len()
+            .map_err(|e| SchedulerError::Msg(format!("store len: {e}")))?
+            as u64;
+        let step_num = already_done / embed_batch_size.max(1) as u64;
+        let batch_num = step_num / steps_per_batch;
+        v.push(SplitState {
+            label,
+            name,
+            store: SrdStoreAdapter(store),
+            mode: embed_mode,
+            emb_dim,
+            max,
+            ratio,
+            total_written: already_done,
+            step_num,
+            batch_num,
+            pending_anchor_vecs: Vec::new(),
+            pending_anchor_texts: Vec::new(),
+            pending_pos_vecs: Vec::new(),
+            pending_pos_texts: Vec::new(),
+            pending_neg_vecs: Vec::new(),
+            pending_neg_texts: Vec::new(),
+            exhausted: false,
+            dropped_batches: 0,
+            total_batches: 0,
+            dropped_samples: 0,
+            start: None,
+            segment_base: already_done,
+        });
+    }
+    Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn srd_store_adapter_write_and_len() {
+        let dir = TempDir::new().unwrap();
+        let ds = DataStore::open(&dir.path().join("test.srd")).unwrap();
+        let adapter = SrdStoreAdapter(ds);
+
+        assert_eq!(adapter.len().unwrap(), 0);
+
+        let vecs = vec![vec![1.0f32, 2.0, 3.0]];
+        let texts = vec!["hello"];
+        adapter
+            .write_pairs(
+                0,
+                &PairWriteArgs {
+                    anchor_vecs: &vecs,
+                    anchor_texts: &texts,
+                    pos_vecs: &vecs,
+                    pos_texts: &texts,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(adapter.len().unwrap(), 1);
+    }
+
+    #[test]
+    fn init_split_states_creates_dirs_and_stores() {
+        let dir = TempDir::new().unwrap();
+        let descs = vec![
+            (SplitLabel::Train, "train", 100u64, 0.8f32),
+            (SplitLabel::Validation, "val", 50, 0.1),
+        ];
+        let states =
+            init_split_states_with_batch(dir.path(), &descs, 32, SrdMode::Pair, 384, 400).unwrap();
+
+        assert_eq!(states.len(), 2);
+        assert_eq!(states[0].label, SplitLabel::Train);
+        assert_eq!(states[1].label, SplitLabel::Validation);
+        assert_eq!(states[0].total_written, 0);
+        assert!(dir.path().join("train").exists());
+        assert!(dir.path().join("val").exists());
+    }
+
+    #[test]
+    fn init_split_states_resumes_existing_store() {
+        let dir = TempDir::new().unwrap();
+        let descs = vec![(SplitLabel::Train, "train", 0u64, 1.0f32)];
+
+        // First call: creates the store, writes some data.
+        {
+            let states =
+                init_split_states_with_batch(dir.path(), &descs, 8, SrdMode::Pair, 4, 400).unwrap();
+            let vecs = vec![vec![1.0f32, 2.0, 3.0, 4.0]; 5];
+            let texts: Vec<&str> = vec!["a", "b", "c", "d", "e"];
+            states[0]
+                .store
+                .write_pairs(
+                    0,
+                    &PairWriteArgs {
+                        anchor_vecs: &vecs,
+                        anchor_texts: &texts,
+                        pos_vecs: &vecs,
+                        pos_texts: &texts,
+                    },
+                )
+                .unwrap();
+        }
+
+        // Second call: should resume with correct total_written.
+        let states =
+            init_split_states_with_batch(dir.path(), &descs, 8, SrdMode::Pair, 4, 400).unwrap();
+        assert_eq!(states[0].total_written, 5);
+        assert_eq!(states[0].step_num, 0); // 5 / 8 = 0
+    }
+
+    #[test]
+    fn srd_store_adapter_write_triplets_and_len() {
+        let dir = TempDir::new().unwrap();
+        let ds = DataStore::open(&dir.path().join("triplets.srd")).unwrap();
+        let adapter = SrdStoreAdapter(ds);
+
+        assert_eq!(adapter.len().unwrap(), 0);
+
+        let anchor_vecs = vec![vec![1.0f32, 2.0, 3.0], vec![4.0, 5.0, 6.0]];
+        let anchor_texts = vec!["a1", "a2"];
+        let pos_vecs = vec![vec![7.0f32, 8.0, 9.0], vec![10.0, 11.0, 12.0]];
+        let pos_texts = vec!["p1", "p2"];
+        let neg_vecs = vec![vec![13.0f32, 14.0, 15.0], vec![16.0, 17.0, 18.0]];
+        let neg_texts = vec!["n1", "n2"];
+
+        adapter
+            .write_triplets(
+                0,
+                &TripletWriteArgs {
+                    anchor_vecs: &anchor_vecs,
+                    anchor_texts: &anchor_texts,
+                    pos_vecs: &pos_vecs,
+                    pos_texts: &pos_texts,
+                    neg_vecs: &neg_vecs,
+                    neg_texts: &neg_texts,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(adapter.len().unwrap(), 2);
+    }
+
+    #[test]
+    fn srd_store_adapter_deref_accesses_inner() {
+        let dir = TempDir::new().unwrap();
+        let ds = DataStore::open(&dir.path().join("deref.srd")).unwrap();
+        let adapter = SrdStoreAdapter(ds);
+
+        // Deref to DataStore and call its inherent len method
+        let inner_len = DataStoreReader::len(&*adapter).unwrap();
+        assert_eq!(inner_len, 0);
+    }
+
+    #[test]
+    fn init_split_states_triplet_mode() {
+        let dir = TempDir::new().unwrap();
+        let descs = vec![(SplitLabel::Train, "train", 100u64, 0.8f32)];
+
+        let states =
+            init_split_states_with_batch(dir.path(), &descs, 32, SrdMode::Triplet, 384, 400)
+                .unwrap();
+
+        assert_eq!(states[0].mode, EmbedMode::Triplet);
+        assert_eq!(states[0].emb_dim, 384);
+    }
+
+    #[test]
+    fn init_split_states_batch_num_computed() {
+        let dir = TempDir::new().unwrap();
+        let descs = vec![(SplitLabel::Train, "train", 0u64, 1.0f32)];
+
+        // Write 20 entries, embed_batch_size=8 → step_num = 20/8 = 2
+        // steps_per_batch=4 → batch_num = 2/4 = 0
+        {
+            let states =
+                init_split_states_with_batch(dir.path(), &descs, 8, SrdMode::Pair, 4, 4).unwrap();
+            let vecs = vec![vec![1.0f32; 4]; 20];
+            let texts: Vec<&str> = (0..20).map(|_i| "").collect();
+            let text_refs: Vec<&str> = texts.iter().map(|s| &**s).collect();
+            states[0]
+                .store
+                .write_pairs(
+                    0,
+                    &PairWriteArgs {
+                        anchor_vecs: &vecs,
+                        anchor_texts: &text_refs,
+                        pos_vecs: &vecs,
+                        pos_texts: &text_refs,
+                    },
+                )
+                .unwrap();
+        }
+
+        let states =
+            init_split_states_with_batch(dir.path(), &descs, 8, SrdMode::Pair, 4, 4).unwrap();
+        assert_eq!(states[0].total_written, 20);
+        assert_eq!(states[0].step_num, 2); // 20 / 8
+        assert_eq!(states[0].batch_num, 0); // 2 / 4
+        assert_eq!(states[0].segment_base, 20);
+    }
+}

--- a/crates/triplets-offline-embedder/src/traits.rs
+++ b/crates/triplets-offline-embedder/src/traits.rs
@@ -1,0 +1,174 @@
+use std::fmt;
+
+use triplets_core::SplitLabel;
+
+/// A batch of texts from the sampler, with separate anchor/positive/negative.
+#[derive(Debug, Clone)]
+pub struct SamplerBatch {
+    /// Anchor texts for this batch.
+    pub anchor_texts: Vec<String>,
+    /// Positive texts for this batch.
+    pub pos_texts: Vec<String>,
+    /// Negative texts (only present in triplet mode).
+    pub neg_texts: Option<Vec<String>>,
+}
+
+/// Error type for scheduler operations.
+#[derive(Debug)]
+pub enum SchedulerError {
+    /// Underlying I/O error.
+    Io(std::io::Error),
+    /// Generic message error.
+    Msg(String),
+}
+
+impl fmt::Display for SchedulerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "{e}"),
+            Self::Msg(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl std::error::Error for SchedulerError {}
+
+impl From<std::io::Error> for SchedulerError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<String> for SchedulerError {
+    fn from(s: String) -> Self {
+        Self::Msg(s)
+    }
+}
+
+impl From<&str> for SchedulerError {
+    fn from(s: &str) -> Self {
+        Self::Msg(s.to_string())
+    }
+}
+
+/// Convenience type alias.
+pub type Result<T> = std::result::Result<T, SchedulerError>;
+
+/// Borrowed arguments for writing a pair batch to a store.
+///
+/// Currently uses `f32` for simplicity — most embedding models output f32 and
+/// simd-r-drive stores raw f32 bytes.  A future change could make this generic
+/// over the element type, but would require a conversion at the storage
+/// boundary.
+#[derive(Debug, Clone)]
+pub struct PairWriteArgs<'a> {
+    /// Embedding vectors for anchor texts.
+    pub anchor_vecs: &'a [Vec<f32>],
+    /// Anchor text strings.
+    pub anchor_texts: &'a [&'a str],
+    /// Embedding vectors for positive texts.
+    pub pos_vecs: &'a [Vec<f32>],
+    /// Positive text strings.
+    pub pos_texts: &'a [&'a str],
+}
+
+/// Borrowed arguments for writing a triplet batch to a store.
+///
+/// Currently uses `f32` for simplicity — most embedding models output f32 and
+/// simd-r-drive stores raw f32 bytes.  A future change could make this generic
+/// over the element type, but would require a conversion at the storage
+/// boundary.
+#[derive(Debug, Clone)]
+pub struct TripletWriteArgs<'a> {
+    /// Embedding vectors for anchor texts.
+    pub anchor_vecs: &'a [Vec<f32>],
+    /// Anchor text strings.
+    pub anchor_texts: &'a [&'a str],
+    /// Embedding vectors for positive texts.
+    pub pos_vecs: &'a [Vec<f32>],
+    /// Positive text strings.
+    pub pos_texts: &'a [&'a str],
+    /// Embedding vectors for negative texts.
+    pub neg_vecs: &'a [Vec<f32>],
+    /// Negative text strings.
+    pub neg_texts: &'a [&'a str],
+}
+
+/// How to write a batch of embeddings + texts to a store.
+pub trait EmbedStore: Send + Sync {
+    /// Write pair entries (anchor + positive) starting at `start_idx`.
+    fn write_pairs(&self, start_idx: u64, args: &PairWriteArgs<'_>) -> Result<()>;
+
+    /// Write triplet entries (anchor + positive + negative) starting at `start_idx`.
+    fn write_triplets(&self, start_idx: u64, args: &TripletWriteArgs<'_>) -> Result<()>;
+
+    /// Current number of entries in the store.
+    fn len(&self) -> Result<u64>;
+
+    /// Returns `true` if the store contains no entries.
+    fn is_empty(&self) -> Result<bool> {
+        self.len().map(|n| n == 0)
+    }
+}
+
+/// How to fetch the next batch of texts from the sampler.
+pub trait BatchProvider: Send + Sync {
+    /// Fetch the next batch for the given split.
+    ///
+    /// Returns `Ok(None)` when the split is exhausted.
+    fn next_batch(&self, split: SplitLabel) -> Result<Option<SamplerBatch>>;
+
+    /// Persist sampler state to disk.
+    fn save_state(&self) -> Result<()>;
+}
+
+/// Embedding callback — the training crate implements this to route embed
+/// calls to the remote teacher (or local model).
+///
+/// Returns `Vec<Vec<f32>>` for simplicity; a future change could parameterise
+/// the element type, but would require a conversion at the storage boundary.
+pub trait Embedder: Send + Sync {
+    /// Embed a batch of texts. Returns vectors in the same order as input.
+    fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>>;
+}
+
+/// Result of a single embed step.
+#[derive(Debug)]
+pub struct StepResult {
+    /// Number of samples successfully processed and accumulated.
+    pub samples_processed: u64,
+    /// Number of samples dropped due to validation failures.
+    pub samples_dropped: u64,
+    /// Whether the pending buffer should be flushed to disk.
+    pub should_flush: bool,
+}
+
+/// Configuration for the offline embedder pipeline.
+#[derive(Clone, Debug)]
+pub struct SchedulerConfig {
+    /// How many texts the sampler produces per call.
+    pub sampler_batch_size: usize,
+    /// How many texts the embedder processes per request.
+    pub embed_batch_size: usize,
+    /// Expected embedding dimension (for validation).
+    pub emb_dim: usize,
+    /// Number of steps between flushes.
+    pub steps_per_batch: u64,
+}
+
+impl SchedulerConfig {
+    /// Create a new config with the given parameters.
+    pub fn new(
+        sampler_batch_size: usize,
+        embed_batch_size: usize,
+        emb_dim: usize,
+        steps_per_batch: u64,
+    ) -> Self {
+        Self {
+            sampler_batch_size,
+            embed_batch_size,
+            emb_dim,
+            steps_per_batch,
+        }
+    }
+}

--- a/crates/triplets-offline-embedder/tests/srd_roundtrip.rs
+++ b/crates/triplets-offline-embedder/tests/srd_roundtrip.rs
@@ -1,0 +1,980 @@
+//! Integration tests: verify data flows correctly through the ACTUAL scheduler
+//! code path (run_interleaved_loop → step → accumulate → flush_pending →
+//! SrdStoreAdapter::write_pairs → file on disk).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tempfile::TempDir;
+
+use triplets_core::SplitLabel;
+use triplets_core::config::SamplerConfig;
+use triplets_core::source::DataSource;
+use triplets_offline_embedder::loop_runner::{LoopEvent, LoopHandler, run_interleaved_loop};
+use triplets_offline_embedder::sampler_prefetcher::SamplerPrefetcher;
+use triplets_offline_embedder::store_adapter::init_split_states_with_batch;
+use triplets_offline_embedder::traits::*;
+use triplets_srd_source::SrdSource;
+use triplets_srd_source::srd_triplet::SrdMode;
+
+// ---------------------------------------------------------------------------
+// Mock infrastructure
+// ---------------------------------------------------------------------------
+
+/// Deterministic embedder: returns vecs where v[0] = hash of text.
+struct TestEmbedder;
+
+impl Embedder for TestEmbedder {
+    fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        Ok(texts
+            .iter()
+            .map(|t| {
+                let id: f32 = t.chars().map(|c| c as u32 as f32).sum();
+                vec![id, 0.0, 0.0]
+            })
+            .collect())
+    }
+}
+
+/// Returns N batches of `batch_size` entries per split, then exhausted.
+struct TestProvider {
+    batches_remaining: std::sync::atomic::AtomicUsize,
+    batch_size: usize,
+}
+
+impl TestProvider {
+    fn new(num_batches: usize, batch_size: usize) -> Self {
+        Self {
+            batches_remaining: std::sync::atomic::AtomicUsize::new(num_batches),
+            batch_size,
+        }
+    }
+}
+
+impl BatchProvider for TestProvider {
+    fn next_batch(&self, _split: SplitLabel) -> Result<Option<SamplerBatch>> {
+        let remaining = self.batches_remaining.fetch_sub(1, Ordering::Relaxed);
+        if remaining == 0 {
+            return Ok(None);
+        }
+        let n = self.batch_size;
+        let anchors: Vec<String> = (0..n).map(|i| format!("anchor_{remaining}_{i}")).collect();
+        let pos: Vec<String> = (0..n).map(|i| format!("pos_{remaining}_{i}")).collect();
+        Ok(Some(SamplerBatch {
+            anchor_texts: anchors,
+            pos_texts: pos,
+            neg_texts: None,
+        }))
+    }
+
+    fn save_state(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct NoopHandler;
+
+impl LoopHandler for NoopHandler {
+    fn handle_event(&mut self, _event: &LoopEvent) {}
+}
+
+/// Split-aware provider: returns different text prefixes per split.
+/// Each split gets its own batch counter so they don't interfere.
+struct SplitAwareProvider {
+    train_batches: std::sync::atomic::AtomicUsize,
+    val_batches: std::sync::atomic::AtomicUsize,
+    batch_size: usize,
+}
+
+impl SplitAwareProvider {
+    fn new(num_batches_per_split: usize, batch_size: usize) -> Self {
+        Self {
+            train_batches: std::sync::atomic::AtomicUsize::new(num_batches_per_split),
+            val_batches: std::sync::atomic::AtomicUsize::new(num_batches_per_split),
+            batch_size,
+        }
+    }
+}
+
+impl BatchProvider for SplitAwareProvider {
+    fn next_batch(&self, split: SplitLabel) -> Result<Option<SamplerBatch>> {
+        let counter = match split {
+            SplitLabel::Train => &self.train_batches,
+            SplitLabel::Validation => &self.val_batches,
+            _ => return Ok(None),
+        };
+        let remaining = counter.fetch_sub(1, Ordering::Relaxed);
+        if remaining == 0 {
+            return Ok(None);
+        }
+        let prefix = match split {
+            SplitLabel::Train => "train",
+            SplitLabel::Validation => "val",
+            _ => "other",
+        };
+        let n = self.batch_size;
+        let anchors: Vec<String> = (0..n)
+            .map(|i| format!("{prefix}_a{remaining}_{i}"))
+            .collect();
+        let pos: Vec<String> = (0..n)
+            .map(|i| format!("{prefix}_p{remaining}_{i}"))
+            .collect();
+        Ok(Some(SamplerBatch {
+            anchor_texts: anchors,
+            pos_texts: pos,
+            neg_texts: None,
+        }))
+    }
+
+    fn save_state(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests through the REAL scheduler code path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scheduler_writes_train_val_to_separate_files() {
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![
+        (SplitLabel::Train, "train", 100u64, 0.8f32),
+        (SplitLabel::Validation, "val", 50u64, 0.2f32),
+    ];
+
+    let mut states =
+        init_split_states_with_batch(dir.path(), &split_descs, 4, SrdMode::Pair, 3, 2).unwrap();
+    assert_eq!(states[0].name, "train");
+    assert_eq!(states[1].name, "val");
+
+    // 2 batches of 2 entries each → 4 entries per split, flushed at steps_per_batch=2
+    let provider = Arc::new(TestProvider::new(2, 2));
+    let embedder = TestEmbedder;
+    let config = SchedulerConfig::new(2, 2, 3, 2);
+
+    let mut prefetchers = HashMap::new();
+    prefetchers.insert(
+        SplitLabel::Train,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+    );
+    prefetchers.insert(
+        SplitLabel::Validation,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Validation, 4),
+    );
+
+    let stop = AtomicBool::new(false);
+    run_interleaved_loop(
+        &mut states,
+        &mut prefetchers,
+        &embedder,
+        provider.as_ref(),
+        &config,
+        &stop,
+        &mut NoopHandler,
+    )
+    .unwrap();
+
+    // Files must exist.
+    assert!(dir.path().join("train/data.srd").exists());
+    assert!(dir.path().join("val/data.srd").exists());
+
+    // Read train via SrdSource — goes through actual file, not mock.
+    let train_source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "train",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let train_snap = train_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert!(!train_snap.records.is_empty(), "train must have data");
+
+    // Read val via SrdSource — goes through actual file, not mock.
+    let val_source =
+        SrdSource::open(&dir.path().join("val/data.srd"), "val", 3, SrdMode::Pair).unwrap();
+    let val_snap = val_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert!(
+        !val_snap.records.is_empty(),
+        "val must have data written by the scheduler"
+    );
+
+    // Cross-check: train must not contain val data.
+    // (pos_* texts are legitimate — they're the positive texts from the sampler)
+    let train_anchors: Vec<&str> = train_snap
+        .records
+        .iter()
+        .map(|r| r.sections[0].text.as_str())
+        .collect();
+    let val_anchors: Vec<&str> = val_snap
+        .records
+        .iter()
+        .map(|r| r.sections[0].text.as_str())
+        .collect();
+    // No anchor text should appear in both splits.
+    for a in &train_anchors {
+        assert!(
+            !val_anchors.contains(a),
+            "anchor '{a}' appears in both train and val"
+        );
+    }
+}
+
+#[test]
+fn scheduler_flush_persists_to_disk() {
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![(SplitLabel::Train, "train", 0u64, 1.0f32)];
+
+    let mut states =
+        init_split_states_with_batch(dir.path(), &split_descs, 2, SrdMode::Pair, 3, 1).unwrap();
+
+    // 3 batches of 2 → 6 entries, flush every 1 step (every batch)
+    let provider = Arc::new(TestProvider::new(3, 2));
+    let embedder = TestEmbedder;
+    let config = SchedulerConfig::new(2, 2, 3, 1);
+
+    let mut prefetchers = HashMap::new();
+    prefetchers.insert(
+        SplitLabel::Train,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+    );
+
+    let stop = AtomicBool::new(false);
+    run_interleaved_loop(
+        &mut states,
+        &mut prefetchers,
+        &embedder,
+        provider.as_ref(),
+        &config,
+        &stop,
+        &mut NoopHandler,
+    )
+    .unwrap();
+
+    // Data must be on disk — open a NEW SrdSource (not reusing state).
+    let source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "verify",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let snap = source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert_eq!(
+        snap.records.len(),
+        6,
+        "scheduler must have written 6 entries to disk"
+    );
+
+    // Verify texts follow the pattern from TestProvider.
+    // (Order may vary due to prefetcher threading, so just verify all entries
+    // have valid anchor texts and total count is correct.)
+    for rec in &snap.records {
+        let text = &rec.sections[0].text;
+        assert!(text.starts_with("anchor_"), "unexpected text: {text}");
+        // Extract the slot index (second part after underscore).
+        let parts: Vec<&str> = text.split('_').collect();
+        assert_eq!(parts.len(), 3, "expected anchor_N_S format: {text}");
+        let slot: usize = parts[2].parse().unwrap();
+        assert!(slot < 2, "slot must be 0 or 1: {text}");
+    }
+}
+
+#[test]
+fn scheduler_resume_adds_to_existing_data() {
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![(SplitLabel::Train, "train", 0u64, 1.0f32)];
+
+    // Session 1: write 2 entries.
+    {
+        let mut states =
+            init_split_states_with_batch(dir.path(), &split_descs, 2, SrdMode::Pair, 3, 1).unwrap();
+        let provider = Arc::new(TestProvider::new(1, 2));
+        let embedder = TestEmbedder;
+        let config = SchedulerConfig::new(2, 2, 3, 1);
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+        );
+        let stop = AtomicBool::new(false);
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut NoopHandler,
+        )
+        .unwrap();
+    }
+
+    // Session 2: write 2 more entries.
+    {
+        let mut states =
+            init_split_states_with_batch(dir.path(), &split_descs, 2, SrdMode::Pair, 3, 1).unwrap();
+        assert_eq!(states[0].total_written, 2, "must resume from session 1");
+        let provider = Arc::new(TestProvider::new(1, 2));
+        let embedder = TestEmbedder;
+        let config = SchedulerConfig::new(2, 2, 3, 1);
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+        );
+        let stop = AtomicBool::new(false);
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut NoopHandler,
+        )
+        .unwrap();
+    }
+
+    // Verify 4 entries on disk, in order.
+    let source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "resume",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let snap = source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert_eq!(snap.records.len(), 4);
+
+    // Session 1 entries (batch remaining=1 → anchor_1_0, anchor_1_1).
+    assert_eq!(snap.records[0].sections[0].text, "anchor_1_0");
+    assert_eq!(snap.records[1].sections[0].text, "anchor_1_1");
+    // Session 2 entries (batch remaining=1 again → anchor_1_0, anchor_1_1).
+    assert_eq!(snap.records[2].sections[0].text, "anchor_1_0");
+    assert_eq!(snap.records[3].sections[0].text, "anchor_1_1");
+}
+
+#[test]
+fn scheduler_ctrl_c_flushes_pending_to_disk() {
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![(SplitLabel::Train, "train", 0u64, 1.0f32)];
+
+    let mut states =
+        init_split_states_with_batch(dir.path(), &split_descs, 2, SrdMode::Pair, 3, 100).unwrap();
+
+    // 5 batches, but stop after 1 step — pending data must be flushed.
+    let provider = Arc::new(TestProvider::new(5, 2));
+    let embedder = TestEmbedder;
+    let config = SchedulerConfig::new(2, 2, 3, 100); // large flush interval
+
+    let mut prefetchers = HashMap::new();
+    prefetchers.insert(
+        SplitLabel::Train,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+    );
+
+    let stop = AtomicBool::new(true); // immediate Ctrl+C
+    run_interleaved_loop(
+        &mut states,
+        &mut prefetchers,
+        &embedder,
+        provider.as_ref(),
+        &config,
+        &stop,
+        &mut NoopHandler,
+    )
+    .unwrap();
+
+    // Must have flushed entries from the step before Ctrl+C was processed.
+    // (The prefetcher may have already buffered a batch, so exact text depends
+    // on timing. Just verify data landed on disk.)
+    let source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "ctrl_c",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let snap = source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert!(
+        !snap.records.is_empty(),
+        "Ctrl+C must flush pending data to disk"
+    );
+    // Verify all records have valid anchor texts from our provider.
+    for rec in &snap.records {
+        assert!(
+            rec.sections[0].text.starts_with("anchor_"),
+            "unexpected text: {}",
+            rec.sections[0].text
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Store-level roundtrip tests (direct DataStore + SrdSource)
+// ---------------------------------------------------------------------------
+
+use simd_r_drive::storage_engine::DataStore;
+use simd_r_drive::storage_engine::traits::DataStoreReader;
+use triplets_core::data::SectionRole;
+use triplets_offline_embedder::traits::EmbedStore;
+use triplets_srd_source::srd_triplet;
+
+#[test]
+fn pair_write_and_read_via_srd_source() {
+    let dir = TempDir::new().unwrap();
+    let store_path = dir.path().join("data.srd");
+
+    // --- scope 1: write data, then drop the store handle ---
+    {
+        let store = DataStore::open(&store_path).unwrap();
+        let anchor_vecs = vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 9.0],
+        ];
+        let anchor_texts = vec!["hello", "world", "foo"];
+        let pos_vecs = vec![
+            vec![10.0, 11.0, 12.0],
+            vec![13.0, 14.0, 15.0],
+            vec![16.0, 17.0, 18.0],
+        ];
+        let pos_texts = vec!["hi", "earth", "bar"];
+        srd_triplet::write_pair_entries(
+            &store,
+            0,
+            &anchor_vecs,
+            &anchor_texts,
+            &pos_vecs,
+            &pos_texts,
+        )
+        .unwrap();
+        assert_eq!(store.len().unwrap(), 3);
+    }
+
+    // --- scope 2: open as SrdSource and read back ---
+    let source = SrdSource::open(&store_path, "test_pair", 3, SrdMode::Pair).unwrap();
+    assert_eq!(source.mode(), SrdMode::Pair);
+
+    let snapshot = source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert_eq!(snapshot.records.len(), 3);
+
+    // Each pair record has 2 sections: Anchor + Context (positive).
+    for (i, rec) in snapshot.records.iter().enumerate() {
+        assert_eq!(rec.sections.len(), 2, "record {i} should have 2 sections");
+        assert_eq!(rec.sections[0].role, SectionRole::Anchor);
+        assert_eq!(rec.sections[1].role, SectionRole::Context);
+    }
+
+    assert_eq!(snapshot.records[0].sections[0].text, "hello");
+    assert_eq!(snapshot.records[0].sections[1].text, "hi");
+    assert_eq!(snapshot.records[1].sections[0].text, "world");
+    assert_eq!(snapshot.records[1].sections[1].text, "earth");
+    assert_eq!(snapshot.records[2].sections[0].text, "foo");
+    assert_eq!(snapshot.records[2].sections[1].text, "bar");
+}
+
+// ---------------------------------------------------------------------------
+// Triplet mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn triplet_write_and_read_via_srd_source() {
+    let dir = TempDir::new().unwrap();
+    let store_path = dir.path().join("data.srd");
+
+    {
+        let store = DataStore::open(&store_path).unwrap();
+        let anchor_vecs = vec![vec![1.0; 4], vec![2.0; 4]];
+        let anchor_texts = vec!["anchor_a", "anchor_b"];
+        let pos_vecs = vec![vec![3.0; 4], vec![4.0; 4]];
+        let pos_texts = vec!["positive_a", "positive_b"];
+        let neg_vecs = vec![vec![5.0; 4], vec![6.0; 4]];
+        let neg_texts = vec!["negative_a", "negative_b"];
+        srd_triplet::write_triplet_entries(
+            &store,
+            0,
+            &anchor_vecs,
+            &anchor_texts,
+            &pos_vecs,
+            &pos_texts,
+            &neg_vecs,
+            &neg_texts,
+        )
+        .unwrap();
+        assert_eq!(store.len().unwrap(), 2);
+    }
+
+    let source = SrdSource::open(&store_path, "test_triplet", 4, SrdMode::Triplet).unwrap();
+    assert_eq!(source.mode(), SrdMode::Triplet);
+
+    let snapshot = source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert_eq!(snapshot.records.len(), 2);
+
+    // Each triplet record has 3 sections: Anchor + Context (positive) + Context (negative).
+    for (i, rec) in snapshot.records.iter().enumerate() {
+        assert_eq!(rec.sections.len(), 3, "record {i} should have 3 sections");
+        assert_eq!(rec.sections[0].role, SectionRole::Anchor);
+        assert_eq!(
+            rec.sections[0].text,
+            format!("anchor_{}", if i == 0 { 'a' } else { 'b' })
+        );
+        assert_eq!(rec.sections[1].role, SectionRole::Context);
+        assert_eq!(
+            rec.sections[1].text,
+            format!("positive_{}", if i == 0 { 'a' } else { 'b' })
+        );
+        assert_eq!(rec.sections[2].role, SectionRole::Context);
+        assert_eq!(
+            rec.sections[2].text,
+            format!("negative_{}", if i == 0 { 'a' } else { 'b' })
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resume: write some, re-open, verify count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resume_after_partial_write() {
+    let dir = TempDir::new().unwrap();
+    let store_path = dir.path().join("data.srd");
+
+    // Write 2 entries.
+    {
+        let store = DataStore::open(&store_path).unwrap();
+        let vecs = vec![vec![1.0; 3]; 2];
+        let texts = vec!["a", "b"];
+        srd_triplet::write_pair_entries(&store, 0, &vecs, &texts, &vecs, &texts).unwrap();
+    }
+
+    // Re-open and verify we can read the 2 existing entries.
+    let source = SrdSource::open(&store_path, "resume_test", 3, SrdMode::Pair).unwrap();
+    let snapshot = source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert_eq!(snapshot.records.len(), 2);
+    assert_eq!(snapshot.records[0].sections[0].text, "a");
+    assert_eq!(snapshot.records[1].sections[0].text, "b");
+}
+
+// ---------------------------------------------------------------------------
+// SrdStoreAdapter roundtrip via init_split_states_with_batch
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adapter_roundtrip_through_split_state() {
+    use triplets_core::SplitLabel;
+    use triplets_offline_embedder::store_adapter::init_split_states_with_batch;
+
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![(SplitLabel::Train, "train", 0u64, 1.0f32)];
+
+    // First call: creates the store, writes via the adapter.
+    {
+        let states =
+            init_split_states_with_batch(dir.path(), &split_descs, 8, SrdMode::Pair, 3, 400)
+                .unwrap();
+        let vecs = vec![vec![1.0, 2.0, 3.0]; 4];
+        let texts: Vec<&str> = vec!["alpha", "beta", "gamma", "delta"];
+        states[0]
+            .store
+            .write_pairs(
+                0,
+                &PairWriteArgs {
+                    anchor_vecs: &vecs,
+                    anchor_texts: &texts,
+                    pos_vecs: &vecs,
+                    pos_texts: &texts,
+                },
+            )
+            .unwrap();
+        assert_eq!(states[0].store.len().unwrap(), 4);
+    }
+
+    // Second call: re-opens the same store file.
+    let states =
+        init_split_states_with_batch(dir.path(), &split_descs, 8, SrdMode::Pair, 3, 400).unwrap();
+    assert_eq!(states[0].total_written, 4);
+    assert_eq!(states[0].store.len().unwrap(), 4);
+
+    // Verify data is readable through SrdSource.
+    let source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "adapter_test",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let snapshot = source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert_eq!(snapshot.records.len(), 4);
+    assert_eq!(snapshot.records[0].sections[0].text, "alpha");
+    assert_eq!(snapshot.records[3].sections[0].text, "delta");
+}
+
+// ---------------------------------------------------------------------------
+// Multi-split tests through the REAL scheduler code path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multi_split_train_val_separate_files() {
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![
+        (SplitLabel::Train, "train", 100u64, 0.8f32),
+        (SplitLabel::Validation, "val", 50u64, 0.2f32),
+    ];
+
+    let mut states =
+        init_split_states_with_batch(dir.path(), &split_descs, 4, SrdMode::Pair, 3, 2).unwrap();
+
+    // 2 batches of 2 → 4 entries per split, flush every 2 steps
+    let provider = Arc::new(SplitAwareProvider::new(2, 2));
+    let embedder = TestEmbedder;
+    let config = SchedulerConfig::new(2, 2, 3, 2);
+
+    let mut prefetchers = HashMap::new();
+    prefetchers.insert(
+        SplitLabel::Train,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+    );
+    prefetchers.insert(
+        SplitLabel::Validation,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Validation, 4),
+    );
+
+    let stop = AtomicBool::new(false);
+    run_interleaved_loop(
+        &mut states,
+        &mut prefetchers,
+        &embedder,
+        provider.as_ref(),
+        &config,
+        &stop,
+        &mut NoopHandler,
+    )
+    .unwrap();
+
+    // Files must exist.
+    assert!(dir.path().join("train/data.srd").exists());
+    assert!(dir.path().join("val/data.srd").exists());
+
+    // Read train via SrdSource.
+    let train_source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "train",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let train_snap = train_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert!(!train_snap.records.is_empty(), "train must have data");
+
+    // Read val via SrdSource.
+    let val_source =
+        SrdSource::open(&dir.path().join("val/data.srd"), "val", 3, SrdMode::Pair).unwrap();
+    let val_snap = val_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert!(!val_snap.records.is_empty(), "val must have data");
+
+    // Cross-check: every anchor in train must start with "train_", every
+    // anchor in val must start with "val_".
+    for rec in &train_snap.records {
+        assert!(
+            rec.sections[0].text.starts_with("train_"),
+            "train contains wrong split data: {}",
+            rec.sections[0].text
+        );
+    }
+    for rec in &val_snap.records {
+        assert!(
+            rec.sections[0].text.starts_with("val_"),
+            "val contains wrong split data: {}",
+            rec.sections[0].text
+        );
+    }
+}
+
+#[test]
+fn multi_split_interleaved_flush_preserves_separation() {
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![
+        (SplitLabel::Train, "train", 100u64, 0.8f32),
+        (SplitLabel::Validation, "val", 50u64, 0.2f32),
+    ];
+
+    let mut states =
+        init_split_states_with_batch(dir.path(), &split_descs, 4, SrdMode::Pair, 3, 1).unwrap();
+
+    // 4 batches of 2, flush every step → interleaved writes to train/val
+    let provider = Arc::new(SplitAwareProvider::new(4, 2));
+    let embedder = TestEmbedder;
+    let config = SchedulerConfig::new(2, 2, 3, 1);
+
+    let mut prefetchers = HashMap::new();
+    prefetchers.insert(
+        SplitLabel::Train,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+    );
+    prefetchers.insert(
+        SplitLabel::Validation,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Validation, 4),
+    );
+
+    let stop = AtomicBool::new(false);
+    run_interleaved_loop(
+        &mut states,
+        &mut prefetchers,
+        &embedder,
+        provider.as_ref(),
+        &config,
+        &stop,
+        &mut NoopHandler,
+    )
+    .unwrap();
+
+    // Verify all train entries have train_ prefix.
+    let train_source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "train_intl",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let train_snap = train_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    for rec in &train_snap.records {
+        assert!(
+            rec.sections[0].text.starts_with("train_"),
+            "interleaved: train contains wrong data: {}",
+            rec.sections[0].text
+        );
+    }
+
+    // Verify all val entries have val_ prefix.
+    let val_source = SrdSource::open(
+        &dir.path().join("val/data.srd"),
+        "val_intl",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let val_snap = val_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    for rec in &val_snap.records {
+        assert!(
+            rec.sections[0].text.starts_with("val_"),
+            "interleaved: val contains wrong data: {}",
+            rec.sections[0].text
+        );
+    }
+}
+
+#[test]
+fn multi_split_resume_preserves_separation() {
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![
+        (SplitLabel::Train, "train", 100u64, 0.8f32),
+        (SplitLabel::Validation, "val", 50u64, 0.2f32),
+    ];
+
+    // Session 1: 2 batches of 2
+    {
+        let mut states =
+            init_split_states_with_batch(dir.path(), &split_descs, 4, SrdMode::Pair, 3, 1).unwrap();
+        let provider = Arc::new(SplitAwareProvider::new(2, 2));
+        let embedder = TestEmbedder;
+        let config = SchedulerConfig::new(2, 2, 3, 1);
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+        );
+        prefetchers.insert(
+            SplitLabel::Validation,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Validation, 4),
+        );
+        let stop = AtomicBool::new(false);
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut NoopHandler,
+        )
+        .unwrap();
+    }
+
+    // Session 2: 2 more batches of 2
+    {
+        let mut states =
+            init_split_states_with_batch(dir.path(), &split_descs, 4, SrdMode::Pair, 3, 1).unwrap();
+        assert_eq!(
+            states[0].total_written, 4,
+            "train must resume from session 1"
+        );
+        assert_eq!(states[1].total_written, 4, "val must resume from session 1");
+        let provider = Arc::new(SplitAwareProvider::new(2, 2));
+        let embedder = TestEmbedder;
+        let config = SchedulerConfig::new(2, 2, 3, 1);
+        let mut prefetchers = HashMap::new();
+        prefetchers.insert(
+            SplitLabel::Train,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+        );
+        prefetchers.insert(
+            SplitLabel::Validation,
+            SamplerPrefetcher::new(provider.clone(), SplitLabel::Validation, 4),
+        );
+        let stop = AtomicBool::new(false);
+        run_interleaved_loop(
+            &mut states,
+            &mut prefetchers,
+            &embedder,
+            provider.as_ref(),
+            &config,
+            &stop,
+            &mut NoopHandler,
+        )
+        .unwrap();
+    }
+
+    // Verify 8 entries per split on disk, all with correct prefix.
+    let train_source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "train_r",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let train_snap = train_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert_eq!(train_snap.records.len(), 8);
+    for rec in &train_snap.records {
+        assert!(rec.sections[0].text.starts_with("train_"));
+    }
+
+    let val_source =
+        SrdSource::open(&dir.path().join("val/data.srd"), "val_r", 3, SrdMode::Pair).unwrap();
+    let val_snap = val_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+    assert_eq!(val_snap.records.len(), 8);
+    for rec in &val_snap.records {
+        assert!(rec.sections[0].text.starts_with("val_"));
+    }
+}
+
+#[test]
+fn multi_split_vectors_not_swapped() {
+    let dir = TempDir::new().unwrap();
+    let split_descs = vec![
+        (SplitLabel::Train, "train", 100u64, 0.8f32),
+        (SplitLabel::Validation, "val", 50u64, 0.2f32),
+    ];
+
+    let mut states =
+        init_split_states_with_batch(dir.path(), &split_descs, 2, SrdMode::Pair, 3, 1).unwrap();
+
+    // 3 batches of 2, flush every step
+    let provider = Arc::new(SplitAwareProvider::new(3, 2));
+    let embedder = TestEmbedder;
+    let config = SchedulerConfig::new(2, 2, 3, 1);
+
+    let mut prefetchers = HashMap::new();
+    prefetchers.insert(
+        SplitLabel::Train,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Train, 4),
+    );
+    prefetchers.insert(
+        SplitLabel::Validation,
+        SamplerPrefetcher::new(provider.clone(), SplitLabel::Validation, 4),
+    );
+
+    let stop = AtomicBool::new(false);
+    run_interleaved_loop(
+        &mut states,
+        &mut prefetchers,
+        &embedder,
+        provider.as_ref(),
+        &config,
+        &stop,
+        &mut NoopHandler,
+    )
+    .unwrap();
+
+    // Verify no anchor text appears in both splits.
+    let train_source = SrdSource::open(
+        &dir.path().join("train/data.srd"),
+        "train_v",
+        3,
+        SrdMode::Pair,
+    )
+    .unwrap();
+    let train_snap = train_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+
+    let val_source =
+        SrdSource::open(&dir.path().join("val/data.srd"), "val_v", 3, SrdMode::Pair).unwrap();
+    let val_snap = val_source
+        .refresh(&SamplerConfig::default(), None, None)
+        .unwrap();
+
+    let train_anchors: Vec<&str> = train_snap
+        .records
+        .iter()
+        .map(|r| r.sections[0].text.as_str())
+        .collect();
+    let val_anchors: Vec<&str> = val_snap
+        .records
+        .iter()
+        .map(|r| r.sections[0].text.as_str())
+        .collect();
+    for a in &train_anchors {
+        assert!(
+            !val_anchors.contains(a),
+            "anchor '{a}' appears in both train and val"
+        );
+    }
+    for a in &val_anchors {
+        assert!(
+            !train_anchors.contains(a),
+            "anchor '{a}' appears in both val and train"
+        );
+    }
+
+    // Verify prefixes.
+    for rec in &train_snap.records {
+        assert!(rec.sections[0].text.starts_with("train_"));
+    }
+    for rec in &val_snap.records {
+        assert!(rec.sections[0].text.starts_with("val_"));
+    }
+}

--- a/crates/triplets-srd-source/Cargo.toml
+++ b/crates/triplets-srd-source/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "triplets-srd-source"
+description = "Experimental simd-r-drive integration for the triplets data pipeline framework."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+categories = ["algorithms", "artificial-intelligence", "science", "text-processing"]
+keywords = [
+    "train-test-split",
+    "triplet-mining",
+    "simd-r-drive",
+    "dataset-sampling",
+    "preprocessing",
+]
+
+[dependencies]
+chrono = { workspace = true }
+simd-r-drive = { workspace = true }
+thiserror = { workspace = true }
+triplets = { workspace = true }
+triplets-core = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+triplets-srd-source = { path = "." }

--- a/crates/triplets-srd-source/README.md
+++ b/crates/triplets-srd-source/README.md
@@ -1,0 +1,3 @@
+Experimental [simd-r-drive](https://crates.io/crates/simd-r-drive) source integration for the [triplets](https://crates.io/crates/triplets) data pipeline framework.
+
+For full documentation on configuring sources, sampling, chunking, and pipeline orchestration, see the [main triplets README](https://github.com/jzombie/rust-triplets/blob/main/README.md) on GitHub.

--- a/crates/triplets-srd-source/src/error.rs
+++ b/crates/triplets-srd-source/src/error.rs
@@ -1,0 +1,75 @@
+use thiserror::Error;
+
+/// Error type for simd-r-drive triplet encoding/decoding operations.
+#[derive(Debug, Error)]
+pub enum SrdError {
+    /// Entry too short for the mode+flags header.
+    #[error("entry too short for mode+flags")]
+    EntryTooShort,
+
+    /// Unknown SrdMode byte encountered.
+    #[error("unknown SrdMode byte: {0}")]
+    UnknownMode(u8),
+
+    /// Truncated text length field.
+    #[error("truncated text length field")]
+    TruncatedTextLength,
+
+    /// Entry data is shorter than expected for embeddings + texts.
+    #[error("entry truncated: {actual} bytes < {expected}")]
+    TruncatedEntry {
+        /// Actual byte count available.
+        actual: usize,
+        /// Expected byte count.
+        expected: usize,
+    },
+
+    /// Invalid UTF-8 in text payload.
+    #[error("invalid UTF-8 in text")]
+    InvalidUtf8(#[from] std::str::Utf8Error),
+
+    /// Embedding dimension must be greater than zero.
+    #[error("embedding dimension must be > 0")]
+    ZeroDimension,
+
+    /// Write batch length mismatch between vectors and texts.
+    #[error("write batch length mismatch: {vec_count} embeddings for {text_count} texts")]
+    BatchLengthMismatch {
+        /// Number of embedding vectors provided.
+        vec_count: usize,
+        /// Number of text strings provided.
+        text_count: usize,
+    },
+
+    /// Inconsistent embedding dimension within a batch.
+    #[error("inconsistent embedding dimension at index {index}: got {got}, expected {expected}")]
+    InconsistentDimension {
+        /// Index of the offending vector.
+        index: usize,
+        /// Dimensionality encountered.
+        got: usize,
+        /// Expected dimensionality.
+        expected: usize,
+    },
+
+    /// Non-finite embedding value detected.
+    #[error("non-finite embedding value at index {index} component {component}")]
+    NonFiniteEmbedding {
+        /// Index of the offending vector.
+        index: usize,
+        /// Component index within the vector.
+        component: usize,
+    },
+
+    /// Anchor and positive batch lengths differ.
+    #[error("anchor/positive batch length mismatch")]
+    PairLengthMismatch,
+
+    /// Anchor, positive, and negative batch lengths differ.
+    #[error("anchor/positive/negative batch length mismatch")]
+    TripletLengthMismatch,
+
+    /// Underlying I/O error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/crates/triplets-srd-source/src/lib.rs
+++ b/crates/triplets-srd-source/src/lib.rs
@@ -1,0 +1,18 @@
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
+
+//! Read and write embedding triplets stored in simd-r-drive format.
+
+/// Error types for SRD operations.
+pub mod error;
+/// Low-level source backed by a simd-r-drive data store.
+pub mod srd_source;
+/// Entry encoding/decoding and batch I/O for pair and triplet modes.
+pub mod srd_triplet;
+
+pub use error::SrdError;
+pub use srd_source::SrdSource;
+pub use srd_triplet::{
+    SrdEntry, SrdMode, batch_read_entries, decode_entry, encode_entry, validate_write_batch,
+    write_pair_entries, write_triplet_entries,
+};

--- a/crates/triplets-srd-source/src/srd_source.rs
+++ b/crates/triplets-srd-source/src/srd_source.rs
@@ -1,0 +1,497 @@
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use chrono::Utc;
+use simd_r_drive::storage_engine::DataStore;
+use simd_r_drive::storage_engine::traits::DataStoreReader;
+use triplets::SamplerError;
+use triplets::config::{NegativeStrategy, SamplerConfig, Selector, TripletRecipe};
+use triplets::data::{DataRecord, QualityScore, RecordSection, SectionRole};
+use triplets::source::{DataSource, SourceCursor, SourceSnapshot};
+use triplets::types::RecordId;
+
+use crate::error::SrdError;
+use crate::srd_triplet::{self, SrdMode};
+
+/// A [`DataSource`] backed by a simd-r-drive embedding store.
+///
+/// Each entry in the store maps to a [`DataRecord`] with 2 sections (pair mode)
+/// or 3 sections (triplet mode), determined by the entry's mode byte.
+///
+/// The `record_id` on each produced [`DataRecord`] is the entry's u64 index
+/// (as a string), enabling downstream consumers to look up precomputed
+/// embeddings from the same store.
+pub struct SrdSource {
+    store: DataStore,
+    source_id: String,
+    entry_count: AtomicU64,
+    mode: SrdMode,
+    emb_dim: usize,
+}
+
+impl SrdSource {
+    /// Open a simd-r-drive store with an explicit mode.
+    ///
+    /// The `mode` parameter must match the data already written to the store
+    /// (or the mode that will be used for writes). This avoids inferring
+    /// schema from the data itself, which is unsafe on empty stores.
+    pub fn open(
+        path: &Path,
+        source_id: impl Into<String>,
+        emb_dim: usize,
+        mode: SrdMode,
+    ) -> Result<Self, SrdError> {
+        let store = DataStore::open_existing(path)?;
+        let count = store.len()? as u64;
+        Ok(Self {
+            store,
+            source_id: source_id.into(),
+            entry_count: AtomicU64::new(count),
+            mode,
+            emb_dim,
+        })
+    }
+
+    /// The detected mode of this store.
+    pub fn mode(&self) -> SrdMode {
+        self.mode
+    }
+}
+
+impl DataSource for SrdSource {
+    fn id(&self) -> &str {
+        &self.source_id
+    }
+
+    fn refresh(
+        &self,
+        _config: &SamplerConfig,
+        cursor: Option<&SourceCursor>,
+        limit: Option<usize>,
+    ) -> Result<SourceSnapshot, SamplerError> {
+        let total = self.entry_count.load(Ordering::Relaxed);
+        let start = cursor.map(|c| c.revision).unwrap_or(0);
+        let batch_size = limit
+            .unwrap_or(256)
+            .min(total.saturating_sub(start) as usize);
+
+        // Batch-read all entries in one call.
+        let indices: Vec<usize> = (start..start + batch_size as u64)
+            .filter(|&i| i < total)
+            .map(|i| i as usize)
+            .collect();
+        let entries = srd_triplet::batch_read_entries(&self.store, &indices, self.emb_dim)
+            .map_err(|e| SamplerError::Configuration(e.to_string()))?;
+
+        let now = Utc::now();
+        let mut records = Vec::with_capacity(entries.len());
+        for (offset, entry) in indices.iter().zip(entries.iter()) {
+            let id: RecordId = (*offset as u64).to_string();
+            let sections = match entry.mode {
+                SrdMode::Pair => vec![
+                    RecordSection {
+                        role: SectionRole::Anchor,
+                        heading: None,
+                        text: entry.anchor_text.clone(),
+                        sentences: vec![],
+                    },
+                    RecordSection {
+                        role: SectionRole::Context,
+                        heading: None,
+                        text: entry.pos_text.clone(),
+                        sentences: vec![],
+                    },
+                ],
+                SrdMode::Triplet => vec![
+                    RecordSection {
+                        role: SectionRole::Anchor,
+                        heading: None,
+                        text: entry.anchor_text.clone(),
+                        sentences: vec![],
+                    },
+                    RecordSection {
+                        role: SectionRole::Context,
+                        heading: None,
+                        text: entry.pos_text.clone(),
+                        sentences: vec![],
+                    },
+                    RecordSection {
+                        role: SectionRole::Context,
+                        heading: None,
+                        text: entry.neg_text.clone().ok_or_else(|| {
+                            SamplerError::Configuration("triplet entry missing neg_text".into())
+                        })?,
+                        sentences: vec![],
+                    },
+                ],
+            };
+            records.push(DataRecord {
+                id,
+                source: self.source_id.clone(),
+                created_at: now,
+                updated_at: now,
+                quality: QualityScore::default(),
+                taxonomy: vec![],
+                sections,
+                meta_prefix: None,
+            });
+        }
+
+        let next_cursor = SourceCursor {
+            last_seen: Utc::now(),
+            revision: start + batch_size as u64,
+        };
+
+        Ok(SourceSnapshot {
+            records,
+            cursor: next_cursor,
+        })
+    }
+
+    fn reported_record_count(&self, _config: &SamplerConfig) -> Result<u128, SamplerError> {
+        Ok(self.entry_count.load(Ordering::Relaxed) as u128)
+    }
+
+    fn default_triplet_recipes(&self) -> Vec<TripletRecipe> {
+        match self.mode {
+            SrdMode::Pair => vec![TripletRecipe {
+                name: "srd_pair".into(),
+                anchor: Selector::Paragraph(0),
+                positive_selector: Selector::Paragraph(1),
+                negative_selector: Selector::Role(SectionRole::Context),
+                negative_strategy: NegativeStrategy::WrongArticle,
+                weight: 1.0,
+                instruction: None,
+                allow_same_anchor_positive: false,
+            }],
+            SrdMode::Triplet => vec![TripletRecipe {
+                name: "srd_triplet".into(),
+                anchor: Selector::Paragraph(0),
+                positive_selector: Selector::Paragraph(1),
+                negative_selector: Selector::Paragraph(2),
+                negative_strategy: NegativeStrategy::SameRecord,
+                weight: 1.0,
+                instruction: None,
+                allow_same_anchor_positive: false,
+            }],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const TEST_EMB_DIM: usize = 768;
+
+    fn make_pair_store(dir: &TempDir, n: usize) {
+        let store = DataStore::open(&dir.path().join("data.srd")).unwrap();
+        let vecs: Vec<Vec<f32>> = (0..n).map(|i| vec![i as f32; TEST_EMB_DIM]).collect();
+        let texts: Vec<String> = (0..n).map(|i| format!("anchor_{i}")).collect();
+        let pos_texts: Vec<String> = (0..n).map(|i| format!("positive_{i}")).collect();
+        let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+        let pos_refs: Vec<&str> = pos_texts.iter().map(|s| s.as_str()).collect();
+        srd_triplet::write_pair_entries(&store, 0, &vecs, &refs, &vecs, &pos_refs).unwrap();
+    }
+
+    fn make_triplet_store(dir: &TempDir, n: usize) {
+        let store = DataStore::open(&dir.path().join("data.srd")).unwrap();
+        let vecs: Vec<Vec<f32>> = (0..n).map(|i| vec![i as f32; TEST_EMB_DIM]).collect();
+        let a_texts: Vec<String> = (0..n).map(|i| format!("anchor_{i}")).collect();
+        let p_texts: Vec<String> = (0..n).map(|i| format!("positive_{i}")).collect();
+        let n_texts: Vec<String> = (0..n).map(|i| format!("negative_{i}")).collect();
+        let a_refs: Vec<&str> = a_texts.iter().map(|s| s.as_str()).collect();
+        let p_refs: Vec<&str> = p_texts.iter().map(|s| s.as_str()).collect();
+        let n_refs: Vec<&str> = n_texts.iter().map(|s| s.as_str()).collect();
+        srd_triplet::write_triplet_entries(
+            &store, 0, &vecs, &a_refs, &vecs, &p_refs, &vecs, &n_refs,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn pair_mode_refresh_returns_two_sections() {
+        let dir = TempDir::new().unwrap();
+        make_pair_store(&dir, 3);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+        assert_eq!(source.mode(), SrdMode::Pair);
+
+        let config = SamplerConfig::default();
+        let snapshot = source.refresh(&config, None, None).unwrap();
+        assert_eq!(snapshot.records.len(), 3);
+
+        for record in &snapshot.records {
+            assert_eq!(record.sections.len(), 2);
+            assert_eq!(record.sections[0].role, SectionRole::Anchor);
+            assert_eq!(record.sections[1].role, SectionRole::Context);
+        }
+    }
+
+    #[test]
+    fn triplet_mode_refresh_returns_three_sections() {
+        let dir = TempDir::new().unwrap();
+        make_triplet_store(&dir, 3);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Triplet,
+        )
+        .unwrap();
+        assert_eq!(source.mode(), SrdMode::Triplet);
+
+        let config = SamplerConfig::default();
+        let snapshot = source.refresh(&config, None, None).unwrap();
+        assert_eq!(snapshot.records.len(), 3);
+
+        for record in &snapshot.records {
+            assert_eq!(record.sections.len(), 3);
+            assert_eq!(record.sections[0].role, SectionRole::Anchor);
+            assert_eq!(record.sections[1].role, SectionRole::Context);
+            assert_eq!(record.sections[2].role, SectionRole::Context);
+        }
+    }
+
+    #[test]
+    fn record_id_matches_entry_index() {
+        let dir = TempDir::new().unwrap();
+        make_pair_store(&dir, 5);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+
+        let config = SamplerConfig::default();
+        let snapshot = source.refresh(&config, None, None).unwrap();
+
+        for (i, record) in snapshot.records.iter().enumerate() {
+            assert_eq!(record.id, i.to_string());
+        }
+    }
+
+    #[test]
+    fn default_recipes_pair_mode() {
+        let dir = TempDir::new().unwrap();
+        make_pair_store(&dir, 1);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+
+        let recipes = source.default_triplet_recipes();
+        assert_eq!(recipes.len(), 1);
+        assert_eq!(recipes[0].name, "srd_pair");
+        assert_eq!(recipes[0].anchor, Selector::Paragraph(0));
+        assert_eq!(recipes[0].positive_selector, Selector::Paragraph(1));
+        assert!(matches!(
+            recipes[0].negative_strategy,
+            NegativeStrategy::WrongArticle
+        ));
+    }
+
+    #[test]
+    fn default_recipes_triplet_mode() {
+        let dir = TempDir::new().unwrap();
+        make_triplet_store(&dir, 1);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Triplet,
+        )
+        .unwrap();
+
+        let recipes = source.default_triplet_recipes();
+        assert_eq!(recipes.len(), 1);
+        assert_eq!(recipes[0].name, "srd_triplet");
+        assert_eq!(recipes[0].anchor, Selector::Paragraph(0));
+        assert_eq!(recipes[0].positive_selector, Selector::Paragraph(1));
+        assert_eq!(recipes[0].negative_selector, Selector::Paragraph(2));
+        assert!(matches!(
+            recipes[0].negative_strategy,
+            NegativeStrategy::SameRecord
+        ));
+    }
+
+    #[test]
+    fn pagination_with_limit() {
+        let dir = TempDir::new().unwrap();
+        make_pair_store(&dir, 5);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+
+        let config = SamplerConfig::default();
+
+        // First page: limit=2
+        let snapshot1 = source.refresh(&config, None, Some(2)).unwrap();
+        assert_eq!(snapshot1.records.len(), 2);
+        assert_eq!(snapshot1.records[0].id, "0");
+        assert_eq!(snapshot1.records[1].id, "1");
+
+        // Second page: use cursor from first page
+        let snapshot2 = source
+            .refresh(&config, Some(&snapshot1.cursor), Some(2))
+            .unwrap();
+        assert_eq!(snapshot2.records.len(), 2);
+        assert_eq!(snapshot2.records[0].id, "2");
+        assert_eq!(snapshot2.records[1].id, "3");
+
+        // Third page: remaining entry
+        let snapshot3 = source
+            .refresh(&config, Some(&snapshot2.cursor), Some(2))
+            .unwrap();
+        assert_eq!(snapshot3.records.len(), 1);
+        assert_eq!(snapshot3.records[0].id, "4");
+    }
+
+    #[test]
+    fn empty_store_returns_empty_records() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("data.srd")).unwrap();
+        // Don't write anything — store is empty
+        drop(store);
+
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+        assert_eq!(source.mode(), SrdMode::Pair);
+
+        let config = SamplerConfig::default();
+        let snapshot = source.refresh(&config, None, None).unwrap();
+        assert!(snapshot.records.is_empty());
+    }
+
+    #[test]
+    fn reported_record_count_matches() {
+        let dir = TempDir::new().unwrap();
+        make_pair_store(&dir, 7);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+
+        let config = SamplerConfig::default();
+        let count = source.reported_record_count(&config).unwrap();
+        assert_eq!(count, 7);
+    }
+
+    #[test]
+    fn pair_mode_texts_match() {
+        let dir = TempDir::new().unwrap();
+        make_pair_store(&dir, 3);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+
+        let config = SamplerConfig::default();
+        let snapshot = source.refresh(&config, None, None).unwrap();
+
+        for (i, record) in snapshot.records.iter().enumerate() {
+            assert_eq!(record.sections[0].text, format!("anchor_{i}"));
+            assert_eq!(record.sections[1].text, format!("positive_{i}"));
+        }
+    }
+
+    #[test]
+    fn triplet_mode_texts_match() {
+        let dir = TempDir::new().unwrap();
+        make_triplet_store(&dir, 3);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Triplet,
+        )
+        .unwrap();
+
+        let config = SamplerConfig::default();
+        let snapshot = source.refresh(&config, None, None).unwrap();
+
+        for (i, record) in snapshot.records.iter().enumerate() {
+            assert_eq!(record.sections[0].text, format!("anchor_{i}"));
+            assert_eq!(record.sections[1].text, format!("positive_{i}"));
+            assert_eq!(record.sections[2].text, format!("negative_{i}"));
+        }
+    }
+
+    #[test]
+    fn source_id_is_set_on_records() {
+        let dir = TempDir::new().unwrap();
+        make_pair_store(&dir, 2);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "my_source",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+
+        let config = SamplerConfig::default();
+        let snapshot = source.refresh(&config, None, None).unwrap();
+
+        for record in &snapshot.records {
+            assert_eq!(record.source, "my_source");
+        }
+    }
+
+    #[test]
+    fn open_nonexistent_path_returns_error() {
+        let result = SrdSource::open(
+            std::path::Path::new("/nonexistent/path/data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn refresh_cursor_past_end_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        make_pair_store(&dir, 3);
+        let source = SrdSource::open(
+            &dir.path().join("data.srd"),
+            "test",
+            TEST_EMB_DIM,
+            SrdMode::Pair,
+        )
+        .unwrap();
+
+        let config = SamplerConfig::default();
+        let cursor = SourceCursor {
+            last_seen: chrono::Utc::now(),
+            revision: 100, // past the end
+        };
+        let snapshot = source.refresh(&config, Some(&cursor), None).unwrap();
+        assert!(snapshot.records.is_empty());
+    }
+}

--- a/crates/triplets-srd-source/src/srd_triplet.rs
+++ b/crates/triplets-srd-source/src/srd_triplet.rs
@@ -1,0 +1,1224 @@
+use simd_r_drive::storage_engine::DataStore;
+use simd_r_drive::storage_engine::traits::{DataStoreReader, DataStoreWriter};
+
+use crate::error::SrdError;
+
+type Result<T> = std::result::Result<T, SrdError>;
+
+/// Mode byte stored as the first byte of each simd-r-drive entry.
+pub const MODE_PAIR: u8 = 0;
+/// Mode byte for triplet entries (anchor + positive + negative).
+pub const MODE_TRIPLET: u8 = 1;
+
+/// Flag bits stored as the second byte of each entry.
+pub const FLAG_POS_SAME: u8 = 1 << 0; // positive same as anchor
+/// Negative-embedding flag: bit 1 indicates negative is the same as anchor (triplet only).
+pub const FLAG_NEG_SAME: u8 = 1 << 1; // negative same as anchor (triplet only)
+
+/// Mode of an simd-r-drive embedding store.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SrdMode {
+    /// Pair mode: anchor + positive per entry.
+    Pair,
+    /// Triplet mode: anchor + positive + negative per entry.
+    Triplet,
+}
+
+impl SrdMode {
+    /// Decode a mode byte into an `SrdMode`.
+    pub fn from_byte(b: u8) -> Result<Self> {
+        match b {
+            MODE_PAIR => Ok(SrdMode::Pair),
+            MODE_TRIPLET => Ok(SrdMode::Triplet),
+            other => Err(SrdError::UnknownMode(other)),
+        }
+    }
+
+    /// Encode this mode as a single byte.
+    pub fn to_byte(self) -> u8 {
+        match self {
+            SrdMode::Pair => MODE_PAIR,
+            SrdMode::Triplet => MODE_TRIPLET,
+        }
+    }
+
+    /// Number of sections (roles) per entry in this mode.
+    pub fn section_count(self) -> usize {
+        match self {
+            SrdMode::Pair => 2,
+            SrdMode::Triplet => 3,
+        }
+    }
+}
+
+/// A decoded simd-r-drive entry containing embeddings and text.
+#[derive(Clone, Debug)]
+pub struct SrdEntry {
+    /// Whether this entry is pair or triplet mode.
+    pub mode: SrdMode,
+    /// True when the positive embedding is the same pointer as the anchor.
+    pub same_as_anchor: bool,
+    /// Anchor embedding vector.
+    pub anchor_emb: Vec<f32>,
+    /// Anchor text string.
+    pub anchor_text: String,
+    /// Positive embedding vector.
+    pub pos_emb: Vec<f32>,
+    /// Positive text string.
+    pub pos_text: String,
+    /// Negative embedding vector (triplet mode only).
+    pub neg_emb: Option<Vec<f32>>,
+    /// Negative text string (triplet mode only).
+    pub neg_text: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Unified encoder
+// ---------------------------------------------------------------------------
+
+/// Encode an entry into bytes using the unified format.
+///
+/// Format: `[mode:1] [flags:1] [text_lens...] [embeddings...] [texts...]`
+///
+/// Flags: bit 0 = pos same as anchor, bit 1 = neg same as anchor.
+/// Only unique embeddings and texts are stored.
+pub fn encode_entry(entry: &SrdEntry) -> Vec<u8> {
+    let emb_dim = entry.anchor_emb.len();
+    let emb_bytes = emb_dim * 4;
+
+    // Compute flags
+    let mut flags: u8 = 0;
+    if entry.same_as_anchor {
+        flags |= FLAG_POS_SAME;
+    }
+    if entry.mode == SrdMode::Triplet
+        && let Some((neg_emb, neg_text)) = entry.neg_emb.as_ref().zip(entry.neg_text.as_ref())
+        && neg_emb == &entry.anchor_emb
+        && neg_text == &entry.anchor_text
+    {
+        flags |= FLAG_NEG_SAME;
+    }
+
+    // Count unique texts and embeddings
+    let unique_texts = match entry.mode {
+        SrdMode::Pair => {
+            if flags & FLAG_POS_SAME != 0 {
+                1
+            } else {
+                2
+            }
+        }
+        SrdMode::Triplet => {
+            let mut n = 1; // anchor always
+            if flags & FLAG_POS_SAME == 0 {
+                n += 1;
+            }
+            if flags & FLAG_NEG_SAME == 0 {
+                n += 1;
+            }
+            n
+        }
+    };
+    let unique_embs = unique_texts; // 1 emb per unique text
+
+    // Compute buffer size
+    let text_lens_size = unique_texts * 4;
+    let embs_size = unique_embs * emb_bytes;
+    let texts_size: usize = match entry.mode {
+        SrdMode::Pair => {
+            if flags & FLAG_POS_SAME != 0 {
+                entry.anchor_text.len()
+            } else {
+                entry.anchor_text.len() + entry.pos_text.len()
+            }
+        }
+        SrdMode::Triplet => {
+            let mut s = entry.anchor_text.len();
+            if flags & FLAG_POS_SAME == 0 {
+                s += entry.pos_text.len();
+            }
+            if let (Some(t), 0) = (&entry.neg_text, flags & FLAG_NEG_SAME) {
+                s += t.len();
+            }
+            s
+        }
+    };
+
+    let mut buf = Vec::with_capacity(2 + text_lens_size + embs_size + texts_size);
+
+    // Header
+    buf.push(entry.mode.to_byte());
+    buf.push(flags);
+
+    // Text lengths
+    match entry.mode {
+        SrdMode::Pair => {
+            buf.extend_from_slice(&(entry.anchor_text.len() as u32).to_le_bytes());
+            if flags & FLAG_POS_SAME == 0 {
+                buf.extend_from_slice(&(entry.pos_text.len() as u32).to_le_bytes());
+            }
+        }
+        SrdMode::Triplet => {
+            buf.extend_from_slice(&(entry.anchor_text.len() as u32).to_le_bytes());
+            if flags & FLAG_POS_SAME == 0 {
+                buf.extend_from_slice(&(entry.pos_text.len() as u32).to_le_bytes());
+            }
+            if flags & FLAG_NEG_SAME == 0 {
+                let n = entry.neg_text.as_ref().map_or(0, |t| t.len());
+                buf.extend_from_slice(&(n as u32).to_le_bytes());
+            }
+        }
+    }
+
+    // Embeddings
+    write_emb_slice(&mut buf, &entry.anchor_emb);
+    if flags & FLAG_POS_SAME == 0 {
+        write_emb_slice(&mut buf, &entry.pos_emb);
+    }
+    if entry.mode == SrdMode::Triplet
+        && flags & FLAG_NEG_SAME == 0
+        && let Some(neg_emb) = &entry.neg_emb
+    {
+        write_emb_slice(&mut buf, neg_emb);
+    }
+
+    // Texts
+    buf.extend_from_slice(entry.anchor_text.as_bytes());
+    if flags & FLAG_POS_SAME == 0 {
+        buf.extend_from_slice(entry.pos_text.as_bytes());
+    }
+    if entry.mode == SrdMode::Triplet
+        && flags & FLAG_NEG_SAME == 0
+        && let Some(neg_text) = &entry.neg_text
+    {
+        buf.extend_from_slice(neg_text.as_bytes());
+    }
+
+    buf
+}
+
+fn write_emb_slice(buf: &mut Vec<u8>, emb: &[f32]) {
+    for &x in emb {
+        buf.extend_from_slice(&x.to_le_bytes());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified decoder
+// ---------------------------------------------------------------------------
+
+/// Decode a raw simd-r-drive entry value into an [`SrdEntry`].
+///
+/// Format: `[mode:1] [flags:1] [text_lens...] [embeddings...] [texts...]`
+/// Reader reconstructs full entry by duplicating anchor where flags indicate sameness.
+pub fn decode_entry(data: &[u8], emb_dim: usize) -> Result<SrdEntry> {
+    if data.len() < 2 {
+        return Err(SrdError::EntryTooShort);
+    }
+    let mode = SrdMode::from_byte(data[0])?;
+    let flags = data[1];
+    let emb_bytes = emb_dim * 4;
+
+    // Count unique texts/embeddings from flags
+    let (unique_texts, pos_same, neg_same) = match mode {
+        SrdMode::Pair => {
+            let pos_same = flags & FLAG_POS_SAME != 0;
+            (if pos_same { 1 } else { 2 }, pos_same, false)
+        }
+        SrdMode::Triplet => {
+            let pos_same = flags & FLAG_POS_SAME != 0;
+            let neg_same = flags & FLAG_NEG_SAME != 0;
+            let n = 1 + if pos_same { 0 } else { 1 } + if neg_same { 0 } else { 1 };
+            (n, pos_same, neg_same)
+        }
+    };
+
+    // Read text lengths
+    let mut offset = 2;
+    let mut text_lens = Vec::with_capacity(unique_texts);
+    for _ in 0..unique_texts {
+        if offset + 4 > data.len() {
+            return Err(SrdError::TruncatedTextLength);
+        }
+        let len = u32::from_le_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+        text_lens.push(len);
+        offset += 4;
+    }
+
+    // Validate enough data for embeddings + texts
+    let embs_size = unique_texts * emb_bytes;
+    let texts_size: usize = text_lens.iter().sum();
+    let expected = offset + embs_size + texts_size;
+    if data.len() < expected {
+        return Err(SrdError::TruncatedEntry {
+            actual: data.len(),
+            expected,
+        });
+    }
+
+    // Read embeddings
+    let mut embs = Vec::with_capacity(unique_texts);
+    for _ in 0..unique_texts {
+        embs.push(decode_emb_slice(&data[offset..offset + emb_bytes], emb_dim));
+        offset += emb_bytes;
+    }
+
+    // Read texts
+    let mut texts = Vec::with_capacity(unique_texts);
+    for &len in &text_lens {
+        let text = std::str::from_utf8(&data[offset..offset + len])?.to_owned();
+        texts.push(text);
+        offset += len;
+    }
+
+    // Reconstruct full entry
+    let anchor_emb = embs[0].clone();
+    let anchor_text = texts[0].clone();
+
+    let (pos_emb, pos_text) = if pos_same {
+        (anchor_emb.clone(), anchor_text.clone())
+    } else {
+        (embs[1].clone(), texts[1].clone())
+    };
+
+    let (neg_emb, neg_text) = match mode {
+        SrdMode::Pair => (None, None),
+        SrdMode::Triplet => {
+            if neg_same {
+                (Some(anchor_emb.clone()), Some(anchor_text.clone()))
+            } else {
+                let idx = 1 + if pos_same { 0 } else { 1 };
+                (Some(embs[idx].clone()), Some(texts[idx].clone()))
+            }
+        }
+    };
+
+    Ok(SrdEntry {
+        mode,
+        same_as_anchor: pos_same,
+        anchor_emb,
+        anchor_text,
+        pos_emb,
+        pos_text,
+        neg_emb,
+        neg_text,
+    })
+}
+
+fn decode_emb_slice(data: &[u8], emb_dim: usize) -> Vec<f32> {
+    data[..emb_dim * 4]
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Batch validation
+// ---------------------------------------------------------------------------
+
+/// Validate that a batch of vectors and texts are consistent before writing.
+pub fn validate_write_batch(vecs: &[Vec<f32>], texts: &[&str]) -> Result<()> {
+    if vecs.len() != texts.len() {
+        return Err(SrdError::BatchLengthMismatch {
+            vec_count: vecs.len(),
+            text_count: texts.len(),
+        });
+    }
+    if vecs.is_empty() {
+        return Ok(());
+    }
+    let dim = vecs[0].len();
+    if dim == 0 {
+        return Err(SrdError::ZeroDimension);
+    }
+    for (i, vec) in vecs.iter().enumerate() {
+        if vec.len() != dim {
+            return Err(SrdError::InconsistentDimension {
+                index: i,
+                got: vec.len(),
+                expected: dim,
+            });
+        }
+        if let Some(j) = vec.iter().position(|x| !x.is_finite()) {
+            return Err(SrdError::NonFiniteEmbedding {
+                index: i,
+                component: j,
+            });
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Batch write
+// ---------------------------------------------------------------------------
+
+/// Batch-write pair entries (anchor + positive) into `store` starting at `start_idx`.
+///
+/// Automatically sets `same_as_anchor` when anchor and positive are identical.
+pub fn write_pair_entries(
+    store: &DataStore,
+    start_idx: u64,
+    anchor_vecs: &[Vec<f32>],
+    anchor_texts: &[&str],
+    pos_vecs: &[Vec<f32>],
+    pos_texts: &[&str],
+) -> Result<()> {
+    validate_write_batch(anchor_vecs, anchor_texts)?;
+    validate_write_batch(pos_vecs, pos_texts)?;
+    if anchor_vecs.len() != pos_vecs.len() {
+        return Err(SrdError::PairLengthMismatch);
+    }
+    let mut key_bufs: Vec<[u8; 8]> = Vec::with_capacity(anchor_vecs.len());
+    let mut value_bufs: Vec<Vec<u8>> = Vec::with_capacity(anchor_vecs.len());
+    for (i, ((a_vec, a_text), (p_vec, p_text))) in anchor_vecs
+        .iter()
+        .zip(anchor_texts.iter())
+        .zip(pos_vecs.iter().zip(pos_texts.iter()))
+        .enumerate()
+    {
+        let same = a_vec == p_vec && a_text == p_text;
+        key_bufs.push((start_idx + i as u64).to_le_bytes());
+        value_bufs.push(encode_entry(&SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: same,
+            anchor_emb: a_vec.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: p_vec.clone(),
+            pos_text: p_text.to_string(),
+            neg_emb: None,
+            neg_text: None,
+        }));
+    }
+    let entries: Vec<(&[u8], &[u8])> = key_bufs
+        .iter()
+        .zip(value_bufs.iter())
+        .map(|(k, v)| (k.as_slice(), v.as_slice()))
+        .collect();
+    store.batch_write(&entries)?;
+    Ok(())
+}
+
+/// Batch-write triplet entries (anchor + positive + negative) into `store` starting at `start_idx`.
+#[allow(clippy::too_many_arguments)]
+pub fn write_triplet_entries(
+    store: &DataStore,
+    start_idx: u64,
+    anchor_vecs: &[Vec<f32>],
+    anchor_texts: &[&str],
+    pos_vecs: &[Vec<f32>],
+    pos_texts: &[&str],
+    neg_vecs: &[Vec<f32>],
+    neg_texts: &[&str],
+) -> Result<()> {
+    validate_write_batch(anchor_vecs, anchor_texts)?;
+    validate_write_batch(pos_vecs, pos_texts)?;
+    validate_write_batch(neg_vecs, neg_texts)?;
+    if anchor_vecs.len() != pos_vecs.len() || pos_vecs.len() != neg_vecs.len() {
+        return Err(SrdError::TripletLengthMismatch);
+    }
+    let mut key_bufs: Vec<[u8; 8]> = Vec::with_capacity(anchor_vecs.len());
+    let mut value_bufs: Vec<Vec<u8>> = Vec::with_capacity(anchor_vecs.len());
+    for (i, (((a_vec, a_text), (p_vec, p_text)), (n_vec, n_text))) in anchor_vecs
+        .iter()
+        .zip(anchor_texts.iter())
+        .zip(pos_vecs.iter().zip(pos_texts.iter()))
+        .zip(neg_vecs.iter().zip(neg_texts.iter()))
+        .enumerate()
+    {
+        let same = a_vec == p_vec && a_text == p_text;
+        key_bufs.push((start_idx + i as u64).to_le_bytes());
+        value_bufs.push(encode_entry(&SrdEntry {
+            mode: SrdMode::Triplet,
+            same_as_anchor: same,
+            anchor_emb: a_vec.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: p_vec.clone(),
+            pos_text: p_text.to_string(),
+            neg_emb: Some(n_vec.clone()),
+            neg_text: Some(n_text.to_string()),
+        }));
+    }
+    let entries: Vec<(&[u8], &[u8])> = key_bufs
+        .iter()
+        .zip(value_bufs.iter())
+        .map(|(k, v)| (k.as_slice(), v.as_slice()))
+        .collect();
+    store.batch_write(&entries)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Batch read
+// ---------------------------------------------------------------------------
+
+/// Batch-read entries from `store` at the given indices and decode each one.
+///
+/// Missing entries (index beyond store length) are silently skipped.
+pub fn batch_read_entries(
+    store: &DataStore,
+    indices: &[usize],
+    emb_dim: usize,
+) -> Result<Vec<SrdEntry>> {
+    let key_bufs: Vec<[u8; 8]> = indices.iter().map(|&i| (i as u64).to_le_bytes()).collect();
+    let keys: Vec<&[u8]> = key_bufs.iter().map(|k| k.as_slice()).collect();
+    let raw = store.batch_read(&keys)?;
+    let mut entries = Vec::with_capacity(indices.len());
+    for entry in raw.into_iter().flatten() {
+        entries.push(decode_entry(entry.as_slice(), emb_dim)?);
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // -----------------------------------------------------------------------
+    // encode/decode roundtrip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn roundtrip_pair() {
+        let a_emb = vec![0.1, 0.2, 0.3];
+        let p_emb = vec![0.4, 0.5, 0.6];
+        let a_text = "anchor text";
+        let p_text = "positive text";
+
+        let entry = SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: false,
+            anchor_emb: a_emb.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: p_emb.clone(),
+            pos_text: p_text.to_string(),
+            neg_emb: None,
+            neg_text: None,
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 3).unwrap();
+
+        assert_eq!(decoded.mode, SrdMode::Pair);
+        assert!(!decoded.same_as_anchor);
+        assert_eq!(decoded.anchor_emb, a_emb);
+        assert_eq!(decoded.anchor_text, a_text);
+        assert_eq!(decoded.pos_emb, p_emb);
+        assert_eq!(decoded.pos_text, p_text);
+        assert!(decoded.neg_emb.is_none());
+        assert!(decoded.neg_text.is_none());
+    }
+
+    #[test]
+    fn roundtrip_pair_same_as_anchor() {
+        let a_emb = vec![0.1, 0.2, 0.3];
+        let a_text = "shared text";
+
+        let entry = SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: true,
+            anchor_emb: a_emb.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: a_emb.clone(),
+            pos_text: a_text.to_string(),
+            neg_emb: None,
+            neg_text: None,
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 3).unwrap();
+
+        assert_eq!(decoded.mode, SrdMode::Pair);
+        assert!(decoded.same_as_anchor);
+        assert_eq!(decoded.anchor_emb, a_emb);
+        assert_eq!(decoded.anchor_text, a_text);
+        assert_eq!(decoded.pos_emb, a_emb);
+        assert_eq!(decoded.pos_text, a_text);
+    }
+
+    #[test]
+    fn pair_same_is_smaller() {
+        let a_emb = vec![0.1, 0.2, 0.3];
+        let a_text = "shared text";
+
+        let full = encode_entry(&SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: false,
+            anchor_emb: a_emb.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: a_emb.clone(),
+            pos_text: a_text.to_string(),
+            neg_emb: None,
+            neg_text: None,
+        });
+        let compact = encode_entry(&SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: true,
+            anchor_emb: a_emb.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: a_emb,
+            pos_text: a_text.to_string(),
+            neg_emb: None,
+            neg_text: None,
+        });
+        assert!(
+            compact.len() < full.len(),
+            "compact ({}) should be smaller than full ({})",
+            compact.len(),
+            full.len()
+        );
+    }
+
+    #[test]
+    fn roundtrip_triplet() {
+        let a_emb = vec![0.1, 0.2, 0.3];
+        let p_emb = vec![0.4, 0.5, 0.6];
+        let n_emb = vec![0.7, 0.8, 0.9];
+        let a_text = "anchor";
+        let p_text = "positive";
+        let n_text = "negative";
+
+        let entry = SrdEntry {
+            mode: SrdMode::Triplet,
+            same_as_anchor: false,
+            anchor_emb: a_emb.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: p_emb.clone(),
+            pos_text: p_text.to_string(),
+            neg_emb: Some(n_emb.clone()),
+            neg_text: Some(n_text.to_string()),
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 3).unwrap();
+
+        assert_eq!(decoded.mode, SrdMode::Triplet);
+        assert_eq!(decoded.anchor_emb, a_emb);
+        assert_eq!(decoded.anchor_text, a_text);
+        assert_eq!(decoded.pos_emb, p_emb);
+        assert_eq!(decoded.pos_text, p_text);
+        assert_eq!(decoded.neg_emb, Some(n_emb));
+        assert_eq!(decoded.neg_text, Some(n_text.to_owned()));
+    }
+
+    #[test]
+    fn roundtrip_triplet_pos_same_as_anchor() {
+        let a_emb = vec![0.1, 0.2, 0.3];
+        let n_emb = vec![0.7, 0.8, 0.9];
+        let a_text = "anchor";
+        let n_text = "negative";
+
+        let entry = SrdEntry {
+            mode: SrdMode::Triplet,
+            same_as_anchor: true,
+            anchor_emb: a_emb.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: a_emb.clone(),
+            pos_text: a_text.to_string(),
+            neg_emb: Some(n_emb.clone()),
+            neg_text: Some(n_text.to_string()),
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 3).unwrap();
+
+        assert_eq!(decoded.mode, SrdMode::Triplet);
+        assert!(decoded.same_as_anchor);
+        assert_eq!(decoded.anchor_emb, a_emb);
+        assert_eq!(decoded.anchor_text, a_text);
+        assert_eq!(decoded.pos_emb, a_emb);
+        assert_eq!(decoded.pos_text, a_text);
+        assert_eq!(decoded.neg_emb, Some(n_emb));
+        assert_eq!(decoded.neg_text, Some(n_text.to_owned()));
+    }
+
+    #[test]
+    fn roundtrip_triplet_all_same() {
+        let a_emb = vec![0.1, 0.2, 0.3];
+        let a_text = "all same";
+
+        let entry = SrdEntry {
+            mode: SrdMode::Triplet,
+            same_as_anchor: true,
+            anchor_emb: a_emb.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: a_emb.clone(),
+            pos_text: a_text.to_string(),
+            neg_emb: Some(a_emb.clone()),
+            neg_text: Some(a_text.to_string()),
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 3).unwrap();
+
+        assert_eq!(decoded.mode, SrdMode::Triplet);
+        assert_eq!(decoded.anchor_emb, a_emb);
+        assert_eq!(decoded.pos_emb, a_emb);
+        assert_eq!(decoded.neg_emb, Some(a_emb));
+    }
+
+    #[test]
+    fn roundtrip_triplet_neg_same_pos_different() {
+        let a_emb = vec![0.1, 0.2, 0.3];
+        let p_emb = vec![0.4, 0.5, 0.6];
+        let n_emb = vec![0.1, 0.2, 0.3]; // same as anchor
+        let a_text = "anchor";
+        let p_text = "positive";
+        let n_text = "anchor"; // same as anchor
+
+        let entry = SrdEntry {
+            mode: SrdMode::Triplet,
+            same_as_anchor: false, // pos is different
+            anchor_emb: a_emb.clone(),
+            anchor_text: a_text.to_string(),
+            pos_emb: p_emb.clone(),
+            pos_text: p_text.to_string(),
+            neg_emb: Some(n_emb.clone()),
+            neg_text: Some(n_text.to_string()),
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 3).unwrap();
+
+        assert_eq!(decoded.mode, SrdMode::Triplet);
+        assert!(!decoded.same_as_anchor);
+        assert_eq!(decoded.anchor_emb, a_emb);
+        assert_eq!(decoded.anchor_text, a_text);
+        assert_eq!(decoded.pos_emb, p_emb);
+        assert_eq!(decoded.pos_text, p_text);
+        assert_eq!(decoded.neg_emb, Some(a_emb)); // neg == anchor
+        assert_eq!(decoded.neg_text, Some(a_text.to_owned())); // neg == anchor
+    }
+
+    #[test]
+    fn pair_empty_text() {
+        let entry = SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: false,
+            anchor_emb: vec![1.0],
+            anchor_text: String::new(),
+            pos_emb: vec![2.0],
+            pos_text: String::new(),
+            neg_emb: None,
+            neg_text: None,
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 1).unwrap();
+        assert_eq!(decoded.mode, SrdMode::Pair);
+        assert_eq!(decoded.anchor_text, "");
+        assert_eq!(decoded.pos_text, "");
+    }
+
+    #[test]
+    fn triplet_unicode_text() {
+        let entry = SrdEntry {
+            mode: SrdMode::Triplet,
+            same_as_anchor: false,
+            anchor_emb: vec![1.0],
+            anchor_text: "hello \u{1F600}".to_string(),
+            pos_emb: vec![2.0],
+            pos_text: "\u{00E9}\u{00E8}\u{00EA}".to_string(),
+            neg_emb: Some(vec![3.0]),
+            neg_text: Some("\u{4E16}\u{754C}".to_string()),
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 1).unwrap();
+        assert_eq!(decoded.anchor_text, "hello \u{1F600}");
+        assert_eq!(decoded.pos_text, "\u{00E9}\u{00E8}\u{00EA}");
+        assert_eq!(decoded.neg_text.as_deref(), Some("\u{4E16}\u{754C}"));
+    }
+
+    #[test]
+    fn decode_empty_returns_error() {
+        assert!(decode_entry(&[], 3).is_err());
+    }
+
+    #[test]
+    fn decode_bad_mode_returns_error() {
+        assert!(decode_entry(&[99, 0], 3).is_err());
+    }
+
+    #[test]
+    fn decode_truncated_returns_error() {
+        assert!(decode_entry(&[0, 0, 0], 3).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // mode byte consistency
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pair_mode_byte_is_zero() {
+        let entry = SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: false,
+            anchor_emb: vec![1.0],
+            anchor_text: "a".into(),
+            pos_emb: vec![2.0],
+            pos_text: "b".into(),
+            neg_emb: None,
+            neg_text: None,
+        };
+        let encoded = encode_entry(&entry);
+        assert_eq!(encoded[0], MODE_PAIR);
+    }
+
+    #[test]
+    fn triplet_mode_byte_is_one() {
+        let entry = SrdEntry {
+            mode: SrdMode::Triplet,
+            same_as_anchor: false,
+            anchor_emb: vec![1.0],
+            anchor_text: "a".into(),
+            pos_emb: vec![2.0],
+            pos_text: "b".into(),
+            neg_emb: Some(vec![3.0]),
+            neg_text: Some("c".into()),
+        };
+        let encoded = encode_entry(&entry);
+        assert_eq!(encoded[0], MODE_TRIPLET);
+    }
+
+    #[test]
+    fn mode_byte_consistency_pair() {
+        let entry = SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: false,
+            anchor_emb: vec![1.0, 2.0],
+            anchor_text: "hello".into(),
+            pos_emb: vec![3.0, 4.0],
+            pos_text: "world".into(),
+            neg_emb: None,
+            neg_text: None,
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 2).unwrap();
+        assert_eq!(decoded.mode, SrdMode::Pair);
+    }
+
+    #[test]
+    fn mode_byte_consistency_triplet() {
+        let entry = SrdEntry {
+            mode: SrdMode::Triplet,
+            same_as_anchor: false,
+            anchor_emb: vec![1.0],
+            anchor_text: "a".into(),
+            pos_emb: vec![2.0],
+            pos_text: "b".into(),
+            neg_emb: Some(vec![3.0]),
+            neg_text: Some("c".into()),
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, 1).unwrap();
+        assert_eq!(decoded.mode, SrdMode::Triplet);
+    }
+
+    // -----------------------------------------------------------------------
+    // large embedding dimension
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn large_emb_dim_roundtrip() {
+        let dim = 2048;
+        let a_emb: Vec<f32> = (0..dim).map(|i| i as f32 * 0.001).collect();
+        let p_emb: Vec<f32> = (0..dim).map(|i| i as f32 * -0.001).collect();
+        let entry = SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: false,
+            anchor_emb: a_emb.clone(),
+            anchor_text: "anchor".into(),
+            pos_emb: p_emb.clone(),
+            pos_text: "positive".into(),
+            neg_emb: None,
+            neg_text: None,
+        };
+        let encoded = encode_entry(&entry);
+        let decoded = decode_entry(&encoded, dim).unwrap();
+        assert_eq!(decoded.anchor_emb, a_emb);
+        assert_eq!(decoded.pos_emb, p_emb);
+    }
+
+    // -----------------------------------------------------------------------
+    // error: truncated text
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn truncated_text_returns_error() {
+        let entry = SrdEntry {
+            mode: SrdMode::Pair,
+            same_as_anchor: false,
+            anchor_emb: vec![1.0],
+            anchor_text: "hello".into(),
+            pos_emb: vec![2.0],
+            pos_text: "world".into(),
+            neg_emb: None,
+            neg_text: None,
+        };
+        let buf = encode_entry(&entry);
+        let truncated = &buf[..buf.len() - 2];
+        assert!(decode_entry(truncated, 1).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // batch write + batch_read roundtrip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn batch_write_read_pair_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+
+        let n = 100;
+        let all_a_emb: Vec<Vec<f32>> = (0..n).map(|i| vec![i as f32, i as f32 + 0.5]).collect();
+        let all_a_text: Vec<String> = (0..n).map(|i| format!("anchor_{i}")).collect();
+        let all_p_emb: Vec<Vec<f32>> = (0..n)
+            .map(|i| vec![i as f32 + 100.0, i as f32 + 100.5])
+            .collect();
+        let all_p_text: Vec<String> = (0..n).map(|i| format!("positive_{i}")).collect();
+
+        let a_refs: Vec<&str> = all_a_text.iter().map(|s| s.as_str()).collect();
+        let p_refs: Vec<&str> = all_p_text.iter().map(|s| s.as_str()).collect();
+
+        write_pair_entries(&store, 0, &all_a_emb, &a_refs, &all_p_emb, &p_refs).unwrap();
+        assert_eq!(store.len().unwrap(), n);
+
+        let indices: Vec<usize> = (0..n).collect();
+        let entries = batch_read_entries(&store, &indices, 2).unwrap();
+        assert_eq!(entries.len(), n);
+
+        for (i, entry) in entries.iter().enumerate() {
+            assert_eq!(entry.mode, SrdMode::Pair);
+            assert_eq!(entry.anchor_emb, all_a_emb[i]);
+            assert_eq!(entry.anchor_text, all_a_text[i]);
+            assert_eq!(entry.pos_emb, all_p_emb[i]);
+            assert_eq!(entry.pos_text, all_p_text[i]);
+        }
+    }
+
+    #[test]
+    fn batch_write_read_triplet_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+
+        let n = 50;
+        let dim = 4;
+        let a_emb: Vec<Vec<f32>> = (0..n).map(|i| vec![i as f32; dim]).collect();
+        let a_text: Vec<String> = (0..n).map(|i| format!("a{i}")).collect();
+        let p_emb: Vec<Vec<f32>> = (0..n).map(|i| vec![i as f32 + 100.0; dim]).collect();
+        let p_text: Vec<String> = (0..n).map(|i| format!("p{i}")).collect();
+        let n_emb: Vec<Vec<f32>> = (0..n).map(|i| vec![i as f32 + 200.0; dim]).collect();
+        let n_text: Vec<String> = (0..n).map(|i| format!("n{i}")).collect();
+
+        let a_refs: Vec<&str> = a_text.iter().map(|s| s.as_str()).collect();
+        let p_refs: Vec<&str> = p_text.iter().map(|s| s.as_str()).collect();
+        let n_refs: Vec<&str> = n_text.iter().map(|s| s.as_str()).collect();
+
+        write_triplet_entries(&store, 0, &a_emb, &a_refs, &p_emb, &p_refs, &n_emb, &n_refs)
+            .unwrap();
+        assert_eq!(store.len().unwrap(), n);
+
+        let indices: Vec<usize> = (0..n).collect();
+        let entries = batch_read_entries(&store, &indices, dim).unwrap();
+        assert_eq!(entries.len(), n);
+
+        for (i, entry) in entries.iter().enumerate() {
+            assert_eq!(entry.mode, SrdMode::Triplet);
+            assert_eq!(entry.anchor_emb, a_emb[i]);
+            assert_eq!(entry.anchor_text, a_text[i]);
+            assert_eq!(entry.pos_emb, p_emb[i]);
+            assert_eq!(entry.pos_text, p_text[i]);
+            assert_eq!(entry.neg_emb.as_ref().unwrap(), &n_emb[i]);
+            assert_eq!(entry.neg_text.as_deref(), Some(n_text[i].as_str()));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // batch read subset / edge cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn batch_read_subset() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+
+        let vecs: Vec<Vec<f32>> = (0..10).map(|i| vec![i as f32]).collect();
+        let texts: Vec<String> = (0..10).map(|i| format!("t{i}")).collect();
+        let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+        write_pair_entries(&store, 0, &vecs, &refs, &vecs, &refs).unwrap();
+
+        let entries = batch_read_entries(&store, &[0, 5, 9], 1).unwrap();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].anchor_text, "t0");
+        assert_eq!(entries[1].anchor_text, "t5");
+        assert_eq!(entries[2].anchor_text, "t9");
+    }
+
+    #[test]
+    fn batch_read_empty_indices() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+        let entries = batch_read_entries(&store, &[], 1).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn batch_read_missing_index_skipped() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+
+        let vecs = vec![vec![1.0], vec![2.0]];
+        let texts = vec!["a", "b"];
+        write_pair_entries(&store, 0, &vecs, &texts, &vecs, &texts).unwrap();
+
+        // Index 99 doesn't exist — should be skipped
+        let entries = batch_read_entries(&store, &[0, 99], 1).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].anchor_text, "a");
+    }
+
+    // -----------------------------------------------------------------------
+    // validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn validate_write_batch_ok() {
+        let vecs = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+        let texts = vec!["hello", "world"];
+        assert!(validate_write_batch(&vecs, &texts).is_ok());
+    }
+
+    #[test]
+    fn validate_write_batch_empty() {
+        let vecs: Vec<Vec<f32>> = vec![];
+        let texts: Vec<&str> = vec![];
+        assert!(validate_write_batch(&vecs, &texts).is_ok());
+    }
+
+    #[test]
+    fn validate_write_batch_len_mismatch() {
+        let vecs = vec![vec![1.0], vec![2.0]];
+        let texts = vec!["hello"];
+        assert!(validate_write_batch(&vecs, &texts).is_err());
+    }
+
+    #[test]
+    fn validate_write_batch_non_finite() {
+        let vecs = vec![vec![1.0, f32::NAN]];
+        let texts = vec!["hello"];
+        assert!(validate_write_batch(&vecs, &texts).is_err());
+    }
+
+    #[test]
+    fn validate_write_batch_inconsistent_dim() {
+        let vecs = vec![vec![1.0, 2.0], vec![3.0]];
+        let texts = vec!["hello", "world"];
+        assert!(validate_write_batch(&vecs, &texts).is_err());
+    }
+
+    #[test]
+    fn validate_write_batch_zero_dim() {
+        let vecs = vec![vec![]];
+        let texts = vec!["hello"];
+        assert!(validate_write_batch(&vecs, &texts).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // write_pair_entries / write_triplet_entries validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn write_pair_entries_rejects_len_mismatch() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+        let a_vecs = vec![vec![1.0], vec![2.0]];
+        let a_texts = vec!["a"];
+        let p_vecs = vec![vec![3.0]];
+        let p_texts = vec!["p"];
+        assert!(write_pair_entries(&store, 0, &a_vecs, &a_texts, &p_vecs, &p_texts).is_err());
+    }
+
+    #[test]
+    fn write_triplet_entries_rejects_len_mismatch() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+        let a_vecs = vec![vec![1.0]];
+        let a_texts = vec!["a"];
+        let p_vecs = vec![vec![2.0], vec![3.0]];
+        let p_texts = vec!["p", "q"];
+        let n_vecs = vec![vec![4.0]];
+        let n_texts = vec!["n"];
+        assert!(
+            write_triplet_entries(
+                &store, 0, &a_vecs, &a_texts, &p_vecs, &p_texts, &n_vecs, &n_texts
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn write_pair_entries_correct_start_idx() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+
+        // Write first batch at idx 0
+        let vecs1 = vec![vec![1.0], vec![2.0]];
+        let texts1 = vec!["a", "b"];
+        write_pair_entries(&store, 0, &vecs1, &texts1, &vecs1, &texts1).unwrap();
+
+        // Write second batch at idx 2
+        let vecs2 = vec![vec![3.0]];
+        let texts2 = vec!["c"];
+        write_pair_entries(&store, 2, &vecs2, &texts2, &vecs2, &texts2).unwrap();
+
+        assert_eq!(store.len().unwrap(), 3);
+
+        let entries = batch_read_entries(&store, &[0, 1, 2], 1).unwrap();
+        assert_eq!(entries[0].anchor_text, "a");
+        assert_eq!(entries[1].anchor_text, "b");
+        assert_eq!(entries[2].anchor_text, "c");
+    }
+
+    // -----------------------------------------------------------------------
+    // start_idx with non-zero offset
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn batch_write_nonzero_start_idx() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+
+        let vecs = vec![vec![1.0, 2.0]];
+        let texts = vec!["first"];
+        write_pair_entries(&store, 5, &vecs, &texts, &vecs, &texts).unwrap();
+
+        let entries = batch_read_entries(&store, &[5], 2).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].anchor_text, "first");
+    }
+
+    // -----------------------------------------------------------------------
+    // cross-batch read safety
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cross_batch_read_safety_pair() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+
+        // Batch A: entry 0 same_as_anchor=true, entry 1 different
+        let a_vecs = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+        let p_vecs = vec![vec![1.0, 2.0], vec![30.0, 40.0]]; // different emb for diff entry
+        let a_texts = vec!["same", "diff_a"];
+        let p_texts = vec!["same", "diff_p"];
+        write_pair_entries(&store, 0, &a_vecs, &a_texts, &p_vecs, &p_texts).unwrap();
+
+        // Batch B: entry 2 same_as_anchor=false, entry 3 same_as_anchor=true
+        let b_vecs = vec![vec![5.0, 6.0], vec![7.0, 8.0]];
+        let b_texts = vec!["batch_b_0", "batch_b_1"];
+        write_pair_entries(&store, 2, &b_vecs, &b_texts, &b_vecs, &b_texts).unwrap();
+
+        assert_eq!(store.len().unwrap(), 4);
+
+        // Read all entries from both batches
+        let entries = batch_read_entries(&store, &[0, 1, 2, 3], 2).unwrap();
+        assert_eq!(entries.len(), 4);
+
+        // Entry 0: same_as_anchor=true
+        assert!(entries[0].same_as_anchor);
+        assert_eq!(entries[0].anchor_text, "same");
+        assert_eq!(entries[0].pos_text, "same");
+        assert_eq!(entries[0].anchor_emb, entries[0].pos_emb);
+
+        // Entry 1: different anchor/pos — verify embedding attribution is correct
+        assert!(!entries[1].same_as_anchor);
+        assert_eq!(entries[1].anchor_text, "diff_a");
+        assert_eq!(entries[1].pos_text, "diff_p");
+        assert_eq!(
+            entries[1].anchor_emb,
+            vec![3.0, 4.0],
+            "anchor embedding should match anchor vec"
+        );
+        assert_eq!(
+            entries[1].pos_emb,
+            vec![30.0, 40.0],
+            "positive embedding should match positive vec"
+        );
+
+        // Entry 2: same anchor/pos (write_pair_entries auto-detects)
+        assert!(entries[2].same_as_anchor);
+        assert_eq!(entries[2].anchor_text, "batch_b_0");
+
+        // Entry 3: same_as_anchor=true
+        assert!(entries[3].same_as_anchor);
+        assert_eq!(entries[3].anchor_text, "batch_b_1");
+        assert_eq!(entries[3].pos_text, "batch_b_1");
+    }
+
+    #[test]
+    fn cross_batch_read_safety_triplet() {
+        let dir = TempDir::new().unwrap();
+        let store = DataStore::open(&dir.path().join("test.srd")).unwrap();
+
+        // Batch A: entry 0 all different (each role gets its own embedding),
+        // entry 1 pos same as anchor (same emb + text as anchor).
+        let a_a_vecs = vec![vec![1.0], vec![2.0]];
+        let a_p_vecs = vec![vec![10.0], vec![2.0]]; // entry 0: distinct pos emb
+        let a_n_vecs = vec![vec![100.0], vec![200.0]]; // entry 0/1: distinct neg emb
+        let a_a_texts = vec!["a0", "a1"];
+        let a_p_texts = vec!["p0", "a1"]; // entry 1 pos same as anchor
+        let a_n_texts = vec!["n0", "n1"];
+        write_triplet_entries(
+            &store, 0, &a_a_vecs, &a_a_texts, &a_p_vecs, &a_p_texts, &a_n_vecs, &a_n_texts,
+        )
+        .unwrap();
+
+        // Batch B: entry 2 all same
+        let b_a_vecs = vec![vec![3.0]];
+        let b_a_texts = vec!["all_same"];
+        let b_p_texts = vec!["all_same"];
+        let b_n_texts = vec!["all_same"];
+        write_triplet_entries(
+            &store, 2, &b_a_vecs, &b_a_texts, &b_a_vecs, &b_p_texts, &b_a_vecs, &b_n_texts,
+        )
+        .unwrap();
+
+        assert_eq!(store.len().unwrap(), 3);
+
+        let entries = batch_read_entries(&store, &[0, 1, 2], 1).unwrap();
+        assert_eq!(entries.len(), 3);
+
+        // Entry 0: all different — verify each embedding matches its role
+        assert!(!entries[0].same_as_anchor);
+        assert_eq!(entries[0].anchor_text, "a0");
+        assert_eq!(entries[0].anchor_emb, vec![1.0]);
+        assert_eq!(entries[0].pos_text, "p0");
+        assert_eq!(
+            entries[0].pos_emb,
+            vec![10.0],
+            "pos emb should be distinct from anchor"
+        );
+        assert_eq!(entries[0].neg_text.as_deref(), Some("n0"));
+        assert_eq!(
+            entries[0].neg_emb.as_ref(),
+            Some(&vec![100.0]),
+            "neg emb should be distinct from anchor and pos"
+        );
+
+        // Entry 1: pos same as anchor
+        assert!(entries[1].same_as_anchor);
+        assert_eq!(entries[1].anchor_text, "a1");
+        assert_eq!(entries[1].pos_text, "a1");
+        assert_eq!(entries[1].neg_text.as_deref(), Some("n1"));
+
+        // Entry 2: all same
+        assert!(entries[2].same_as_anchor);
+        assert_eq!(entries[2].anchor_text, "all_same");
+        assert_eq!(entries[2].pos_text, "all_same");
+        assert_eq!(entries[2].neg_text.as_deref(), Some("all_same"));
+        assert_eq!(entries[2].anchor_emb, entries[2].pos_emb);
+        assert_eq!(
+            entries[2].anchor_emb,
+            entries[2].neg_emb.as_ref().unwrap().clone()
+        );
+    }
+}


### PR DESCRIPTION
Introduces two new crates for knowledge distillation data preparation:

- `triplets-srd-source`: Low-level read/write for pair and triplet embeddings stored in simd-r-drive format, with entry encoding, batch I/O, and `SrdSource` for resumable reads.

- `triplets-offline-embedder`: Offline data materialization engine that fetches batches from a sampler, embeds via a pluggable teacher callback, and writes results to per-split stores. Features interleaved split scheduling, background prefetching, a 5% error-rate circuit breaker, zero-copy validation, and Ctrl+C-safe flushing.

Also extends the `Sampler` trait with a `save_sampler_state` hook and adds documentation for the offline embedding pipeline to the README.